### PR TITLE
feat: [WLEO-541] Add `parseAuthorizeRequest` method

### DIFF
--- a/packages/oid4vp/README.md
+++ b/packages/oid4vp/README.md
@@ -1,0 +1,117 @@
+## @pagopa/io-wallet-oid4vp
+
+This package provides functionalities to manage the **OpenID for Verifiable Presentations (OID4VP)** protocol flow, specifically tailored for the Italian Wallet ecosystem. It simplifies the creation of wallet attestations required during the credential issuance process.
+
+## Installation
+
+To install the package, use your preferred package manager:
+
+```bash
+# Using pnpm
+pnpm add @pagopa/io-wallet-oid4vp
+
+# Using yarn
+yarn add @pagopa/io-wallet-oid4vp
+```
+
+## Usage
+
+### Verifying a received Request object
+
+```typescript
+import { parseAuthorizeRequest } from '@pagopa/io-wallet-oid4vci';
+
+//Request Object JWT containing the requested credentials obtained from the RP
+const requestObjectJwt = "ey..." 
+
+//Obtain the signer
+const signer = {
+    method : 'jwk',
+    publicJwk : {/*... jwk details*/},
+    alg : 'ES256'
+}
+
+//Prepare the callbacks
+const callbacks = {
+    verifyJwt : async (signer, {header, payload, compact}) => {
+        const result = //signature verification
+        return {
+            verified : result,
+            signerJwk : signer.publicJwk //Mandatory only if signature is verified correctly
+        }
+    }
+}
+
+//Decode, verify and return the Request Object
+const parsedRequestObject = await parseAuthorizeRequest({
+    requestObjectJwt,
+    callbacks,
+    dpop : {signer}
+});
+```
+
+## API Reference
+
+### AuthorizationRequestObject type and Zod parser
+```typescript
+export const zOpenid4vpAuthorizationRequest = z
+  .object({
+    response_type: z.literal('vp_token'),
+    client_id: z.string(),
+    response_uri: z.string().url().optional(),
+    request_uri: z.string().url().optional(),
+    request_uri_method: z.optional(z.string()),
+    response_mode: z.literal("direct_post.jwt"),
+    nonce: z.string(),
+    wallet_nonce: z.string().optional(),
+    scope: z.string().optional(),
+    dcql_query: z.record(z.string(), z.any()).optional(),
+    state: z.string().optional(),
+  })
+  .passthrough().and(zJwtPayload)
+
+export type AuthorizationRequestObject = z.infer<typeof zOpenid4vpAuthorizationRequest>
+```
+
+### parseAuthorizeRequest
+```typescript
+export interface ParseAuthorizeRequestOptions {
+    /**
+     * The Authorization Request Object JWT.
+     */
+    requestObjectJwt : string ;
+
+    /**
+     * Callback context for signature verification.
+     */
+    callbacks : Pick<CallbackContext, 'verifyJwt'>
+
+    /**
+     * DPoP options
+     */
+    dpop: RequestDpopOptions
+}
+
+export async function parseAuthorizeRequest(options: ParseAuthorizeRequestOptions) : Promise<AuthorizationRequestObject> {
+    ...
+}
+```
+This method receives a Request Object in JWT format, verifies the signature and returns the decoded Request Object.
+
+### Errors
+
+```typescript
+export class AuthorizationRequestParsingError extends Error {
+    constructor(message: string) {
+        super(message) ;
+        this.name = 'AuthorizationRequestParsingError'
+    }
+}
+
+export class Oid4vpParseError extends Error {
+    constructor(message : string) {
+        super(message);
+        this.name = 'Oid4vpParseError'
+    }
+}
+```

--- a/packages/oid4vp/package.json
+++ b/packages/oid4vp/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@pagopa/io-wallet-oid4vp",
+  "version": "0.3.0",
+  "files": [
+    "dist"
+  ],
+  "license": "Apache-2.0",
+  "exports": "./src/index.ts",
+  "homepage": "https://github.com/pagopa/io-wallet-sdk/tree/main/packages/oid4vp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pagopa/io-wallet-sdk",
+    "directory": "packages/oid4vp"
+  },
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "./package.json": "./package.json"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@openid4vc/oauth2": "0.3.0-alpha-20250513122832",
+    "@openid4vc/utils": "0.3.0-alpha-20250513122832",
+    "@openid4vc/openid4vp": "0.3.0-alpha-20250513122832",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "jose": "^6.1.0"
+  }
+}

--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -2,7 +2,7 @@ import { CallbackContext, JwtSignerJwk } from "@openid4vc/oauth2";
 import { AuthorizationRequestObject } from "../z-request-object";
 import {describe, it, expect} from 'vitest'
 import { parseAuthorizeRequest } from "../parse-authorization-request";
-import { Oid4vpParseError } from "../../error";
+import { Oid4vpParsingError } from "../../error";
 import { AuthorizationRequestParsingError } from "../errors";
 const jose = import('jose')
 
@@ -114,7 +114,7 @@ describe('parseAuthorizationRequest tests', async () => {
             requestObjectJwt : missingMandatoryFieldRequestObjectJwt,
             dpop : {signer},
             callbacks 
-        })).rejects.toThrow(Oid4vpParseError)
+        })).rejects.toThrow(Oid4vpParsingError)
     })
 
     it('should throw an Oid4vpParseError for non conforming structure', () => {
@@ -122,7 +122,7 @@ describe('parseAuthorizationRequest tests', async () => {
             requestObjectJwt : nonConformingRequestObjectJwt,
             dpop : {signer},
             callbacks 
-        })).rejects.toThrow(Oid4vpParseError)
+        })).rejects.toThrow(Oid4vpParsingError)
     })
 
     it('should parse and verify the request object correctly since expiration is not checked', async () => {
@@ -139,7 +139,7 @@ describe('parseAuthorizationRequest tests', async () => {
             requestObjectJwt : 'this is not a JWT',
             dpop : {signer},
             callbacks 
-        })).rejects.toThrow(Oid4vpParseError)
+        })).rejects.toThrow(Oid4vpParsingError)
     })
 
     it('should throw an AuthorizationRequestParsingError because of a malformed signature', () => {

--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -1,0 +1,176 @@
+import { CallbackContext, JwtSignerJwk } from "@openid4vc/oauth2";
+import { AuthorizationRequestObject } from "../z-request-object";
+import {describe, it, expect} from 'vitest'
+import { parseAuthorizeRequest } from "../parse-authorization-request";
+import { Oid4vpParseError } from "../../error";
+import { AuthorizationRequestParsingError } from "../errors";
+const jose = import('jose')
+
+const publicKey = {
+  kty: 'EC',
+  x: 'PHIgk53SKmRS3W4FVcv-JoeR9lCAsMa0dUZCKxqO05k',
+  y: 'EzFFYlGAcw5cjcbKey7bYz0CX3hX2raWPokqOB60wCI',
+  crv: 'P-256'
+}
+
+const wrongPublicKey = {
+  kty: 'EC',
+  x: 'VJ23NtKusfLrtx1a2CMsieJJ8PiI_olk6RgLEN7xuEU',
+  y: 'NU5kLnG73gcamaSd4rilxgNRiz5WmO-EE0zCKe0hG8c',
+  crv: 'P-256'
+}
+
+const wrongPubKeySigner : JwtSignerJwk = {
+    method : 'jwk',
+    publicJwk :  wrongPublicKey,
+    alg : 'ES256'
+}
+
+const signer : JwtSignerJwk = {
+    method : 'jwk',
+    publicJwk :  publicKey,
+    alg : 'ES256'
+}
+
+
+const correctRequestObject : AuthorizationRequestObject = {
+    response_type : 'vp_token',
+    client_id : 'test-client-id',
+    response_uri : 'uri://response.example.com',
+    request_uri : "uri://request.example.com",
+    request_uri_method : "POST",
+    response_mode : "direct_post.jwt",
+    nonce : 'test_nonce',
+    wallet_nonce : "Test wallet nonce",
+    scope : 'test_presentation_scope',
+    state : 'test_state',
+    dcql_query : {},
+    iss : 'test-client-id',
+    iat : new Date('2025-09-15').getTime(),
+    exp : new Date('2035-09-15').getTime()
+}
+const correctRequestObjectJwt = "eyJhbGciOiJFUzI1NiJ9.eyJyZXNwb25zZV90eXBlIjoidnBfdG9rZW4iLCJjbGllbnRfaWQiOiJ0ZXN0LWNsaWVudC1pZCIsInJlc3BvbnNlX3VyaSI6InVyaTovL3Jlc3BvbnNlLmV4YW1wbGUuY29tIiwicmVxdWVzdF91cmkiOiJ1cmk6Ly9yZXF1ZXN0LmV4YW1wbGUuY29tIiwicmVxdWVzdF91cmlfbWV0aG9kIjoiUE9TVCIsInJlc3BvbnNlX21vZGUiOiJkaXJlY3RfcG9zdC5qd3QiLCJub25jZSI6InRlc3Rfbm9uY2UiLCJ3YWxsZXRfbm9uY2UiOiJUZXN0IHdhbGxldCBub25jZSIsInNjb3BlIjoidGVzdF9wcmVzZW50YXRpb25fc2NvcGUiLCJzdGF0ZSI6InRlc3Rfc3RhdGUiLCJkY3FsX3F1ZXJ5Ijp7fSwiaXNzIjoidGVzdC1jbGllbnQtaWQiLCJpYXQiOjE3NTc4OTQ0MDAwMDAsImV4cCI6MjA3MzQyNzIwMDAwMH0.GT369294NeghTjkOYTeNgz7U59ZO921Ln9w7-NDieM-QwIfXIL7Iw3n2vzKCHnIbOIrjOnNVRS-aA66tGAXSzg"
+
+/**
+ * The missingMandatoryFieldRequestObjectJwt is obtained by signing the missingMandatoryFieldRequestObject defined below
+ * const {response_type : _ , ...missingMandatoryFieldRequestObject} = correctRequestObject
+ */
+const missingMandatoryFieldRequestObjectJwt = 'eyJhbGciOiJFUzI1NiJ9.eyJjbGllbnRfaWQiOiJ0ZXN0LWNsaWVudC1pZCIsInJlc3BvbnNlX3VyaSI6InVyaTovL3Jlc3BvbnNlLmV4YW1wbGUuY29tIiwicmVxdWVzdF91cmkiOiJ1cmk6Ly9yZXF1ZXN0LmV4YW1wbGUuY29tIiwicmVxdWVzdF91cmlfbWV0aG9kIjoiUE9TVCIsInJlc3BvbnNlX21vZGUiOiJkaXJlY3RfcG9zdC5qd3QiLCJub25jZSI6InRlc3Rfbm9uY2UiLCJ3YWxsZXRfbm9uY2UiOiJUZXN0IHdhbGxldCBub25jZSIsInNjb3BlIjoidGVzdF9wcmVzZW50YXRpb25fc2NvcGUiLCJzdGF0ZSI6InRlc3Rfc3RhdGUiLCJkY3FsX3F1ZXJ5Ijp7fSwiaXNzIjoidGVzdC1jbGllbnQtaWQiLCJpYXQiOjE3NTc4OTQ0MDAwMDAsImV4cCI6MjA3MzQyNzIwMDAwMH0.yLnTKqriqWMaNGWbppY0HVoQ63VEzbD4isG9VGm61uhn6aB9js7juxjQQZ9W0qJrOUhYVwipg8HsWeUCBHbH5w'
+
+/**
+ * The nonConformingRequestObjectJwt is obtained by signing this object
+ * const nonConformingRequestObject = {
+ *     ...correctRequestObject,
+ *     response_type : 3,
+ *     response_uri : 'this is not a uri',
+ *     request_uri : undefined,
+ *     response_mode : 'direct_post',
+ *     dcql_query : [],
+ * }
+ */
+const nonConformingRequestObjectJwt = 'eyJhbGciOiJFUzI1NiJ9.eyJyZXNwb25zZV90eXBlIjozLCJjbGllbnRfaWQiOiJ0ZXN0LWNsaWVudC1pZCIsInJlc3BvbnNlX3VyaSI6InRoaXMgaXMgbm90IGEgdXJpIiwicmVxdWVzdF91cmlfbWV0aG9kIjoiUE9TVCIsInJlc3BvbnNlX21vZGUiOiJkaXJlY3RfcG9zdCIsIm5vbmNlIjoidGVzdF9ub25jZSIsIndhbGxldF9ub25jZSI6IlRlc3Qgd2FsbGV0IG5vbmNlIiwic2NvcGUiOiJ0ZXN0X3ByZXNlbnRhdGlvbl9zY29wZSIsInN0YXRlIjoidGVzdF9zdGF0ZSIsImRjcWxfcXVlcnkiOltdLCJpc3MiOiJ0ZXN0LWNsaWVudC1pZCIsImlhdCI6MTc1Nzg5NDQwMDAwMCwiZXhwIjoyMDczNDI3MjAwMDAwfQ.G1uqCoFcvdUR8JxQOnrUKfRr388mLEwltwx06kH9TOT-SReyB4syUBhADYjf3AjI89OGvsGkTOVbfe2MOxwW5w'
+
+const expiredRequestObject = {
+    ...correctRequestObject,
+    exp : new Date('2025-09-16').getTime()
+}
+const expiredRequestObjectJwt = 'eyJhbGciOiJFUzI1NiJ9.eyJyZXNwb25zZV90eXBlIjoidnBfdG9rZW4iLCJjbGllbnRfaWQiOiJ0ZXN0LWNsaWVudC1pZCIsInJlc3BvbnNlX3VyaSI6InVyaTovL3Jlc3BvbnNlLmV4YW1wbGUuY29tIiwicmVxdWVzdF91cmkiOiJ1cmk6Ly9yZXF1ZXN0LmV4YW1wbGUuY29tIiwicmVxdWVzdF91cmlfbWV0aG9kIjoiUE9TVCIsInJlc3BvbnNlX21vZGUiOiJkaXJlY3RfcG9zdC5qd3QiLCJub25jZSI6InRlc3Rfbm9uY2UiLCJ3YWxsZXRfbm9uY2UiOiJUZXN0IHdhbGxldCBub25jZSIsInNjb3BlIjoidGVzdF9wcmVzZW50YXRpb25fc2NvcGUiLCJzdGF0ZSI6InRlc3Rfc3RhdGUiLCJkY3FsX3F1ZXJ5Ijp7fSwiaXNzIjoidGVzdC1jbGllbnQtaWQiLCJpYXQiOjE3NTc4OTQ0MDAwMDAsImV4cCI6MTc1Nzk4MDgwMDAwMH0.KqO6GEbcB4rS8I5PPaxDZurG1ni2ti95ZCdSawcfXf74uNvtJoNL-Wx7gz3mUUtkakIaICsMi-dgbN4u6SibDA'
+
+const callbacks: Pick<CallbackContext, 'verifyJwt'> = {
+    verifyJwt : async (signer, {compact}) => {
+        const {jwtVerify} = await jose
+        if (signer.method === 'jwk') {
+            try {
+                await jwtVerify(compact, signer.publicJwk)
+                return {
+                    verified : true,
+                    signerJwk : signer.publicJwk
+                }
+            } catch {
+                return {
+                    verified : false,
+                }
+            }
+        }
+        return {
+            verified : false
+        }
+    }
+}
+
+describe('parseAuthorizationRequest tests', async () => {
+
+    it('should parse and verify the request object correctly', async () => {
+        const actualRequestObject = await parseAuthorizeRequest({
+            requestObjectJwt : correctRequestObjectJwt,
+            dpop : {signer},
+            callbacks 
+        })
+        expect(actualRequestObject).toEqual(correctRequestObject)
+    })
+
+    it('should throw an OidvpParseError for missing mandatory fields', () => {
+        expect(async () => await parseAuthorizeRequest({
+            requestObjectJwt : missingMandatoryFieldRequestObjectJwt,
+            dpop : {signer},
+            callbacks 
+        })).rejects.toThrow(Oid4vpParseError)
+    })
+
+    it('should throw an Oid4vpParseError for non conforming structure', () => {
+        expect(async () => await parseAuthorizeRequest({
+            requestObjectJwt : nonConformingRequestObjectJwt,
+            dpop : {signer},
+            callbacks 
+        })).rejects.toThrow(Oid4vpParseError)
+    })
+
+    it('should parse and verify the request object correctly since expiration is not checked', async () => {
+        const actualRequestObject = await parseAuthorizeRequest({
+            requestObjectJwt : expiredRequestObjectJwt,
+            dpop : {signer},
+            callbacks 
+        })
+        expect(actualRequestObject).toEqual(expiredRequestObject)
+    })
+
+    it('should throw an Oid4vpParseError because of a malformed jwt', () => {
+        expect(async () => parseAuthorizeRequest({
+            requestObjectJwt : 'this is not a JWT',
+            dpop : {signer},
+            callbacks 
+        })).rejects.toThrow(Oid4vpParseError)
+    })
+
+    it('should throw an AuthorizationRequestParsingError because of a malformed signature', () => {
+        expect(async () => {
+            const [head, payload] = (correctRequestObjectJwt).split('.')
+            await parseAuthorizeRequest({
+                requestObjectJwt : `${head}.${payload}.this_is_not_a_signature`,
+                dpop : {signer},
+                callbacks 
+            })
+        }).rejects.toThrow(AuthorizationRequestParsingError)
+    })
+
+    it('should throw an AuthorizationRequestParsingError because of a missing signature', () => {
+        expect(async () => {
+            const [head, payload] = (correctRequestObjectJwt).split('.')
+            await parseAuthorizeRequest({
+                requestObjectJwt : `${head}.${payload}.`,
+                dpop : {signer},
+                callbacks 
+            })
+        }).rejects.toThrow(AuthorizationRequestParsingError)
+    })
+
+    it('should throw an AuthorizationRequestParsingError because of a mismatching public key signer', () => {
+        expect(async () => {
+            await parseAuthorizeRequest({
+                requestObjectJwt : correctRequestObjectJwt,
+                dpop : {signer : wrongPubKeySigner},
+                callbacks 
+            })
+        }).rejects.toThrow(AuthorizationRequestParsingError)
+    })
+})

--- a/packages/oid4vp/src/authorization-request/errors.ts
+++ b/packages/oid4vp/src/authorization-request/errors.ts
@@ -1,0 +1,7 @@
+
+export class AuthorizationRequestParsingError extends Error {
+    constructor(message: string) {
+        super(message) ;
+        this.name = 'AuthorizationRequestParsingError'
+    }
+}

--- a/packages/oid4vp/src/authorization-request/index.ts
+++ b/packages/oid4vp/src/authorization-request/index.ts
@@ -1,0 +1,4 @@
+
+export * from './errors'
+export * from './z-request-object'
+export * from './parse-authorization-request'

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -1,0 +1,49 @@
+import { CallbackContext, decodeJwt, Oauth2JwtParseError, RequestDpopOptions } from '@openid4vc/oauth2'
+import { AuthorizationRequestObject, zOpenid4vpAuthorizationRequest } from './z-request-object';
+import { AuthorizationRequestParsingError } from './errors';
+import { Oid4vpParseError } from '../error/Oid4vpParseError';
+import { ValidationError } from '@openid4vc/utils';
+
+export interface ParseAuthorizeRequestOptions {
+    /**
+     * The Authorization Request Object JWT.
+     */
+    requestObjectJwt : string ;
+
+    /**
+     * Callback context for signature verification.
+     */
+    callbacks : Pick<CallbackContext, 'verifyJwt'>
+
+    /**
+     * DPoP options
+     */
+    dpop: RequestDpopOptions
+}
+
+export async function parseAuthorizeRequest(options: ParseAuthorizeRequestOptions) : Promise<AuthorizationRequestObject> {
+
+    try {
+        const decoded = decodeJwt({
+            jwt : options.requestObjectJwt,
+            payloadSchema : zOpenid4vpAuthorizationRequest
+        })
+        const verificationResult = await options.callbacks.verifyJwt(options.dpop.signer,{
+            compact : options.requestObjectJwt,
+            header : decoded.header,
+            payload : decoded.payload
+        })
+
+        if (!verificationResult.verified) throw new AuthorizationRequestParsingError("Error verifying Request Object signature")
+
+        return decoded.payload
+
+    } catch (error) {
+        if (error instanceof Oauth2JwtParseError || error instanceof ValidationError) {
+            throw new Oid4vpParseError(error.message)
+        }
+        throw new AuthorizationRequestParsingError(
+            `Unexpected error during Request Object parsing: ${error instanceof Error ? error.message : String(error)}`
+        );
+    }
+}

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -1,7 +1,7 @@
 import { CallbackContext, decodeJwt, Oauth2JwtParseError, RequestDpopOptions } from '@openid4vc/oauth2'
 import { AuthorizationRequestObject, zOpenid4vpAuthorizationRequest } from './z-request-object';
 import { AuthorizationRequestParsingError } from './errors';
-import { Oid4vpParseError } from '../error/Oid4vpParseError';
+import { Oid4vpParsingError } from '../error/Oid4vpParsingError';
 import { ValidationError } from '@openid4vc/utils';
 
 export interface ParseAuthorizeRequestOptions {
@@ -40,7 +40,7 @@ export async function parseAuthorizeRequest(options: ParseAuthorizeRequestOption
 
     } catch (error) {
         if (error instanceof Oauth2JwtParseError || error instanceof ValidationError) {
-            throw new Oid4vpParseError(error.message)
+            throw new Oid4vpParsingError(error.message)
         }
         throw new AuthorizationRequestParsingError(
             `Unexpected error during Request Object parsing: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/oid4vp/src/authorization-request/z-request-object.ts
+++ b/packages/oid4vp/src/authorization-request/z-request-object.ts
@@ -1,0 +1,20 @@
+import { zJwtPayload } from '@openid4vc/oauth2'
+import {z} from 'zod'
+
+export const zOpenid4vpAuthorizationRequest = z
+  .object({
+    response_type: z.literal('vp_token'),
+    client_id: z.string(),
+    response_uri: z.string().url().optional(),
+    request_uri: z.string().url().optional(),
+    request_uri_method: z.optional(z.string()),
+    response_mode: z.literal("direct_post.jwt"),
+    nonce: z.string(),
+    wallet_nonce: z.string().optional(),
+    scope: z.string().optional(),
+    dcql_query: z.record(z.string(), z.any()).optional(),
+    state: z.string().optional(),
+  })
+  .passthrough().and(zJwtPayload)
+
+export type AuthorizationRequestObject = z.infer<typeof zOpenid4vpAuthorizationRequest>

--- a/packages/oid4vp/src/error/Oid4vpParseError.ts
+++ b/packages/oid4vp/src/error/Oid4vpParseError.ts
@@ -1,7 +1,0 @@
-
-export class Oid4vpParseError extends Error {
-    constructor(message : string) {
-        super(message);
-        this.name = 'Oid4vpParseError'
-    }
-}

--- a/packages/oid4vp/src/error/Oid4vpParseError.ts
+++ b/packages/oid4vp/src/error/Oid4vpParseError.ts
@@ -1,0 +1,7 @@
+
+export class Oid4vpParseError extends Error {
+    constructor(message : string) {
+        super(message);
+        this.name = 'Oid4vpParseError'
+    }
+}

--- a/packages/oid4vp/src/error/Oid4vpParsingError.ts
+++ b/packages/oid4vp/src/error/Oid4vpParsingError.ts
@@ -1,0 +1,7 @@
+
+export class Oid4vpParsingError extends Error {
+    constructor(message : string) {
+        super(message);
+        this.name = 'Oid4vpParsingError'
+    }
+}

--- a/packages/oid4vp/src/error/index.ts
+++ b/packages/oid4vp/src/error/index.ts
@@ -1,2 +1,2 @@
 
-export * from './Oid4vpParseError'
+export * from './Oid4vpParsingError'

--- a/packages/oid4vp/src/error/index.ts
+++ b/packages/oid4vp/src/error/index.ts
@@ -1,0 +1,2 @@
+
+export * from './Oid4vpParseError'

--- a/packages/oid4vp/src/index.ts
+++ b/packages/oid4vp/src/index.ts
@@ -1,0 +1,3 @@
+
+export * from './error'
+export * from './authorization-request'

--- a/packages/oid4vp/tsconfig.json
+++ b/packages/oid4vp/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,25 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
 
+  packages/oid4vp:
+    dependencies:
+      '@openid4vc/oauth2':
+        specifier: 0.3.0-alpha-20250513122832
+        version: 0.3.0-alpha-20250513122832
+      '@openid4vc/openid4vp':
+        specifier: 0.3.0-alpha-20250513122832
+        version: 0.3.0-alpha-20250513122832
+      '@openid4vc/utils':
+        specifier: 0.3.0-alpha-20250513122832
+        version: 0.3.0-alpha-20250513122832
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      jose:
+        specifier: ^6.1.0
+        version: 6.1.0
+
 packages:
 
   '@babel/runtime@7.28.2':
@@ -371,6 +390,9 @@ packages:
 
   '@openid4vc/openid4vci@0.3.0-alpha-20250513122832':
     resolution: {integrity: sha512-lInvFMm0oEH0ys7UbYqNfgVrDY8Bq6nSAkMK77bRcmeqV7YJOzLlLeU16PR3XPjURvIwyXBBiKSknRvwAMBzSg==}
+
+  '@openid4vc/openid4vp@0.3.0-alpha-20250513122832':
+    resolution: {integrity: sha512-FsnGS/CbRbqS3L9Ic0ArqMCRXgExBURPmAUDGOPZ7JAcWaWuX6wK2djaQOfGbN36v6k+Ti+4jm4VhcCNh35E1g==}
 
   '@openid4vc/utils@0.2.0':
     resolution: {integrity: sha512-CvZxy9eH8582Yb/gzc+XPiaQIbC7Y0IT3F14szGS++o6373dUN12KZQzey4hoRrVO92D04vCXyJY9xctw4zgMw==}
@@ -1091,6 +1113,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jose@6.1.0:
+    resolution: {integrity: sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -2059,6 +2084,12 @@ snapshots:
       '@openid4vc/utils': 0.3.0-alpha-20250513122832
       zod: 3.25.76
 
+  '@openid4vc/openid4vp@0.3.0-alpha-20250513122832':
+    dependencies:
+      '@openid4vc/oauth2': 0.3.0-alpha-20250513122832
+      '@openid4vc/utils': 0.3.0-alpha-20250513122832
+      zod: 3.25.76
+
   '@openid4vc/utils@0.2.0(typescript@5.8.3)':
     dependencies:
       buffer: 6.0.3
@@ -2812,6 +2843,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jose@6.1.0: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR adds a new `oid4vp` package that exports a `parseAuthorizeRequest` method which parses and verifies signatures of authorization requests JWTs.
#### List of Changes

<!--- Describe your changes in detail -->
- Created the `oid4vp` package.
- Added the `parseAuthorizeRequest` method in package's `authorization-request` directory with proper tests.
- Added a package-wide `Oid4vpParsingError` that should be thrown on general parsing errors within the library and `AuthorizationRequestParsingError` for errors related to the `parseAuthorizeRequest` method (more specifically, when there are errors verifying the Request Object JWT signature verification.
- Added documentation in package's `README.md`.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR solves issue [WLEO-541], introducing new functionalities to the Wallet SDK.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Proper test cases have been introduces which will be executed by the CI infrastructure.
To test locally, it is sufficient to run `pnpm test` in the project's root.
