### PR TITLE
Add optional error message prefixes for JWT decoding

### DIFF
--- a/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
@@ -74,7 +74,10 @@ export async function parsePushedAuthorizationRequest(
       jarRequestParams: parsed,
     });
 
-    const jwt = decodeJwt({ jwt: parsedJar.authorizationRequestJwt });
+    const jwt = decodeJwt({
+      errorMessagePrefix: "Error decoding pushed authorization request JWT:",
+      jwt: parsedJar.authorizationRequestJwt,
+    });
 
     parsedAuthorizationRequest = zAuthorizationRequest.safeParse(jwt.payload);
     if (!parsedAuthorizationRequest.success) {

--- a/packages/oauth2/src/authorization-request/verify-pushed-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/verify-pushed-authorization-request.ts
@@ -167,7 +167,10 @@ export async function verifyPushedAuthorizationRequest(
   if (options.authorizationRequestJwt) {
     // Fail-fast: reject alg="none" before expensive signature verification (RFC 9101 Section 10.5)
     if (requireSigned) {
-      const decoded = decodeJwt({ jwt: options.authorizationRequestJwt.jwt });
+      const decoded = decodeJwt({
+        errorMessagePrefix: "Error decoding authorization request JWT:",
+        jwt: options.authorizationRequestJwt.jwt,
+      });
       if (decoded.header.alg === "none") {
         throw new PushedAuthorizationRequestError(
           'Authorization Server requires signed request objects, but JAR has algorithm "none"',

--- a/packages/oauth2/src/authorization-request/verify-pushed-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/verify-pushed-authorization-request.ts
@@ -168,7 +168,7 @@ export async function verifyPushedAuthorizationRequest(
     // Fail-fast: reject alg="none" before expensive signature verification (RFC 9101 Section 10.5)
     if (requireSigned) {
       const decoded = decodeJwt({
-        errorMessagePrefix: "Error decoding authorization request JWT:",
+        errorMessagePrefix: "Error decoding pushed authorization request JWT:",
         jwt: options.authorizationRequestJwt.jwt,
       });
       if (decoded.header.alg === "none") {

--- a/packages/oauth2/src/client-attestation/client-attestation-pop.ts
+++ b/packages/oauth2/src/client-attestation/client-attestation-pop.ts
@@ -59,6 +59,7 @@ export async function verifyClientAttestationPopJwt(
 ) {
   try {
     const { header, payload } = decodeJwt({
+      errorMessagePrefix: "Error decoding client attestation PoP JWT:",
       jwt: options.clientAttestationPopJwt,
     });
 
@@ -143,6 +144,7 @@ export async function createClientAttestationPopJwt(
 ) {
   try {
     const clientAttestation = decodeJwt({
+      errorMessagePrefix: "Error decoding client attestation JWT:",
       jwt: options.clientAttestation,
     });
 

--- a/packages/oauth2/src/client-attestation/v1.0/create-wallet-attestation-jwt.ts
+++ b/packages/oauth2/src/client-attestation/v1.0/create-wallet-attestation-jwt.ts
@@ -77,6 +77,7 @@ export const createWalletAttestationJwt = async (
     });
 
     decodeJwt({
+      errorMessagePrefix: "Error decoding wallet attestation JWT:",
       headerSchema: zWalletAttestationJwtHeaderV1_0,
       jwt: result.jwt,
       payloadSchema: zWalletAttestationJwtPayloadV1_0,

--- a/packages/oauth2/src/client-attestation/v1.3/create-wallet-attestation-jwt.ts
+++ b/packages/oauth2/src/client-attestation/v1.3/create-wallet-attestation-jwt.ts
@@ -95,6 +95,7 @@ export const createWalletAttestationJwt = async (
 
     // Validate the generated JWT structure
     decodeJwt({
+      errorMessagePrefix: "Error decoding wallet attestation JWT:",
       headerSchema: zWalletAttestationJwtHeaderV1_3,
       jwt: result.jwt,
       payloadSchema: zWalletAttestationJwtPayloadV1_3,

--- a/packages/oauth2/src/client-attestation/verify-wallet-attestation-jwt-base.ts
+++ b/packages/oauth2/src/client-attestation/verify-wallet-attestation-jwt-base.ts
@@ -16,6 +16,7 @@ export async function verifyWalletAttestationBase<
   payloadSchema: TPayload,
 ) {
   const { header, payload } = decodeJwt({
+    errorMessagePrefix: "Error decoding wallet attestation JWT:",
     headerSchema,
     jwt: options.walletAttestationJwt,
     payloadSchema,

--- a/packages/oauth2/src/common/jwt/decode-jwt-header.ts
+++ b/packages/oauth2/src/common/jwt/decode-jwt-header.ts
@@ -3,6 +3,7 @@ import {
   BaseSchema,
   decodeBase64,
   encodeToUtf8String,
+  formatError,
   parseWithErrorHandling,
   stringToJsonWithErrorHandling,
 } from "@pagopa/io-wallet-utils";
@@ -45,7 +46,10 @@ export function decodeJwtHeader<
   const jwtParts = options.jwt.split(".");
   if (jwtParts.length <= 2) {
     throw new Oauth2JwtParseError(
-      `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+      formatError(
+        "Unable to decode because Jwt is not a valid!",
+        options.errorMessagePrefix,
+      ),
     );
   }
 
@@ -55,18 +59,24 @@ export function decodeJwtHeader<
   try {
     headerJson = stringToJsonWithErrorHandling(
       encodeToUtf8String(decodeBase64(headerPart)),
-      `${options.errorMessagePrefix ?? ""} Unable to parse jwt header to JSON`,
+      formatError(
+        "Unable to parse jwt header to JSON",
+        options.errorMessagePrefix,
+      ),
     );
   } catch (error) {
     throw new Oauth2JwtParseError(
-      `${options.errorMessagePrefix ?? ""} Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
+      formatError(
+        `Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
+        options.errorMessagePrefix,
+      ),
     );
   }
 
   const header = parseWithErrorHandling(
     options.headerSchema ?? zJwtHeader,
     headerJson,
-    `${options.errorMessagePrefix ?? ""} Invalid JWT header:`,
+    formatError("Invalid JWT header", options.errorMessagePrefix),
   ) as InferSchemaOrDefaultOutput<HeaderSchema, typeof zJwtHeader>;
 
   return {

--- a/packages/oauth2/src/common/jwt/decode-jwt-header.ts
+++ b/packages/oauth2/src/common/jwt/decode-jwt-header.ts
@@ -15,6 +15,11 @@ export interface DecodeJwtHeaderOptions<
   HeaderSchema extends BaseSchema | undefined,
 > {
   /**
+   * Optional prefix for error messages thrown during decoding, to provide more context on where the error occurred
+   */
+  errorMessagePrefix?: string;
+
+  /**
    * Schema to use for validating the header. If not provided the
    * default `zJwtHeader` schema will be used
    */
@@ -39,7 +44,9 @@ export function decodeJwtHeader<
 ): DecodeJwtHeaderResult<HeaderSchema> {
   const jwtParts = options.jwt.split(".");
   if (jwtParts.length <= 2) {
-    throw new Oauth2JwtParseError("Jwt is not a valid jwt, unable to decode");
+    throw new Oauth2JwtParseError(
+      `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+    );
   }
 
   const [headerPart] = jwtParts as [string, ...string[]];
@@ -48,17 +55,18 @@ export function decodeJwtHeader<
   try {
     headerJson = stringToJsonWithErrorHandling(
       encodeToUtf8String(decodeBase64(headerPart)),
-      "Unable to parse jwt header to JSON",
+      `${options.errorMessagePrefix ?? ""} Unable to parse jwt header to JSON`,
     );
   } catch (error) {
     throw new Oauth2JwtParseError(
-      `Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
+      `${options.errorMessagePrefix ?? ""} Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
     );
   }
 
   const header = parseWithErrorHandling(
     options.headerSchema ?? zJwtHeader,
     headerJson,
+    `${options.errorMessagePrefix ?? ""} Invalid JWT header:`,
   ) as InferSchemaOrDefaultOutput<HeaderSchema, typeof zJwtHeader>;
 
   return {

--- a/packages/oauth2/src/common/jwt/decode-jwt.ts
+++ b/packages/oauth2/src/common/jwt/decode-jwt.ts
@@ -3,6 +3,7 @@ import {
   BaseSchema,
   decodeBase64,
   encodeToUtf8String,
+  formatError,
   parseWithErrorHandling,
   stringToJsonWithErrorHandling,
 } from "@pagopa/io-wallet-utils";
@@ -56,7 +57,10 @@ export function decodeJwt<
   const jwtParts = options.jwt.split(".");
   if (jwtParts.length !== 3) {
     throw new Oauth2JwtParseError(
-      `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+      formatError(
+        "Unable to decode because Jwt is not a valid!",
+        options.errorMessagePrefix,
+      ),
     );
   }
 
@@ -65,23 +69,35 @@ export function decodeJwt<
     const payloadPart = jwtParts[1];
     if (payloadPart === undefined) {
       throw new Oauth2JwtParseError(
-        `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+        formatError(
+          "Unable to decode because Jwt is not a valid!",
+          options.errorMessagePrefix,
+        ),
       );
     }
     payloadJson = stringToJsonWithErrorHandling(
       encodeToUtf8String(decodeBase64(payloadPart)),
-      `${options.errorMessagePrefix ?? ""} Unable to parse jwt payload to JSON`,
+      formatError(
+        "Unable to parse jwt payload to JSON",
+        options.errorMessagePrefix,
+      ),
     );
   } catch (error) {
     throw new Oauth2JwtParseError(
-      `${options.errorMessagePrefix ?? ""} Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
+      formatError(
+        `Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
+        options.errorMessagePrefix,
+      ),
     );
   }
 
   const signaturePart = jwtParts[2];
   if (signaturePart === undefined) {
     throw new Oauth2JwtParseError(
-      `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+      formatError(
+        "Unable to decode because Jwt is not a valid!",
+        options.errorMessagePrefix,
+      ),
     );
   }
 
@@ -93,7 +109,7 @@ export function decodeJwt<
   const payload = parseWithErrorHandling(
     options.payloadSchema ?? zJwtPayload,
     payloadJson,
-    `${options.errorMessagePrefix ?? ""} Invalid JWT payload:`,
+    formatError("Invalid JWT payload", options.errorMessagePrefix),
   );
 
   return {

--- a/packages/oauth2/src/common/jwt/decode-jwt.ts
+++ b/packages/oauth2/src/common/jwt/decode-jwt.ts
@@ -16,6 +16,11 @@ export interface DecodeJwtOptions<
   PayloadSchema extends BaseSchema | undefined,
 > {
   /**
+   * Optional prefix for error messages thrown during decoding, to provide more context on where the error occurred
+   */
+  errorMessagePrefix?: string;
+
+  /**
    * Schema to use for validating the header. If not provided the
    * default `zJwtHeader` schema will be used
    */
@@ -50,37 +55,45 @@ export function decodeJwt<
 ): DecodeJwtResult<HeaderSchema, PayloadSchema> {
   const jwtParts = options.jwt.split(".");
   if (jwtParts.length !== 3) {
-    throw new Oauth2JwtParseError("Jwt is not a valid jwt, unable to decode");
+    throw new Oauth2JwtParseError(
+      `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+    );
   }
 
   let payloadJson: Record<string, unknown>;
   try {
     const payloadPart = jwtParts[1];
     if (payloadPart === undefined) {
-      throw new Oauth2JwtParseError("Jwt is not a valid jwt, unable to decode");
+      throw new Oauth2JwtParseError(
+        `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+      );
     }
     payloadJson = stringToJsonWithErrorHandling(
       encodeToUtf8String(decodeBase64(payloadPart)),
-      "Unable to parse jwt payload to JSON",
+      `${options.errorMessagePrefix ?? ""} Unable to parse jwt payload to JSON`,
     );
   } catch (error) {
     throw new Oauth2JwtParseError(
-      `Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
+      `${options.errorMessagePrefix ?? ""} Error parsing JWT. ${error instanceof Error ? error.message : ""}`,
     );
   }
 
   const signaturePart = jwtParts[2];
   if (signaturePart === undefined) {
-    throw new Oauth2JwtParseError("Jwt is not a valid jwt, unable to decode");
+    throw new Oauth2JwtParseError(
+      `${options.errorMessagePrefix ?? ""} Unable to decode because Jwt is not a valid!`,
+    );
   }
 
   const { header } = decodeJwtHeader({
+    errorMessagePrefix: options.errorMessagePrefix,
     headerSchema: options.headerSchema,
     jwt: options.jwt,
   });
   const payload = parseWithErrorHandling(
     options.payloadSchema ?? zJwtPayload,
     payloadJson,
+    `${options.errorMessagePrefix ?? ""} Invalid JWT payload:`,
   );
 
   return {

--- a/packages/oauth2/src/jar/verify-jar-request.ts
+++ b/packages/oauth2/src/jar/verify-jar-request.ts
@@ -2,13 +2,13 @@ import {
   CallbackContext,
   JwtSigner,
   JwtSignerWithJwk,
-  decodeJwt,
   verifyJwt,
   zCompactJwe,
   zCompactJwt,
 } from "@openid4vc/oauth2";
 import { parseWithErrorHandling } from "@pagopa/io-wallet-utils";
 
+import { decodeJwt } from "../common/jwt/decode-jwt";
 import { Oauth2Error } from "../errors";
 import {
   JarRequestObjectPayload,
@@ -132,7 +132,10 @@ async function verifyJarRequestObject(options: {
 }) {
   const { authorizationRequestJwt, callbacks, jwtSigner } = options;
 
-  const jwt = decodeJwt({ jwt: authorizationRequestJwt });
+  const jwt = decodeJwt({
+    errorMessagePrefix: "Error decoding JAR authorization request JWT:",
+    jwt: authorizationRequestJwt,
+  });
   const authorizationRequestPayload = parseWithErrorHandling(
     zJarRequestObjectPayload,
     jwt.payload,

--- a/packages/oauth2/src/jarm-form-post-jwt.ts
+++ b/packages/oauth2/src/jarm-form-post-jwt.ts
@@ -68,6 +68,7 @@ export const getJwtFromFormPost = async <T>(
         if (responseJwt) {
           const jwt = responseJwt.replace(lineExpressionRegex, "");
           const decodedJwt = decodeJwt({
+            errorMessagePrefix: "Error decoding JARM form post JWT:",
             jwt,
             payloadSchema: options.schema,
           });

--- a/packages/oauth2/src/mrtd-pop/fetch-mrtd-pop-init.ts
+++ b/packages/oauth2/src/mrtd-pop/fetch-mrtd-pop-init.ts
@@ -91,6 +91,7 @@ export async function fetchMrtdPopInit(
     const responseJwt = await response.text();
 
     const jwt = decodeJwt({
+      errorMessagePrefix: "Error decoding MRTD PoP init response JWT:",
       headerSchema: zMrtdPopInitResponseJwtHeader,
       jwt: responseJwt,
       payloadSchema: zMrtdPopInitResponseJwtPayload,

--- a/packages/oauth2/src/mrtd-pop/parse-mrtd-challenge.ts
+++ b/packages/oauth2/src/mrtd-pop/parse-mrtd-challenge.ts
@@ -52,6 +52,7 @@ export function parseMrtdChallenge(
   }
 
   const { header, payload } = decodeJwt({
+    errorMessagePrefix: "Error decoding MRTD challenge JWT:",
     headerSchema: zMrtdChallengeJwtHeader,
     jwt: challengeJwt,
     payloadSchema: zMrtdChallengeJwtPayload,

--- a/packages/oauth2/src/mrtd-pop/verify-mrtd-challenge.ts
+++ b/packages/oauth2/src/mrtd-pop/verify-mrtd-challenge.ts
@@ -54,6 +54,7 @@ export async function verifyMrtdChallenge(
   const { callbacks, challengeJwt, clientId } = options;
 
   const jwt = decodeJwt({
+    errorMessagePrefix: "Error decoding MRTD challenge JWT:",
     headerSchema: zMrtdChallengeJwtHeader,
     jwt: challengeJwt,
     payloadSchema: zMrtdChallengeJwtPayload,

--- a/packages/oauth2/src/token-dpop/verify-token-dpop.ts
+++ b/packages/oauth2/src/token-dpop/verify-token-dpop.ts
@@ -69,6 +69,7 @@ export interface VerifyTokenDPoPOptions {
 
 export async function verifyTokenDPoP(options: VerifyTokenDPoPOptions) {
   const { header, payload } = decodeJwt({
+    errorMessagePrefix: "Error decoding DPoP JWT:",
     headerSchema: zDpopJwtHeader,
     jwt: options.dpopJwt,
     payloadSchema: zDpopJwtPayload,

--- a/packages/oauth2/src/token-dpop/verify-token-dpop.ts
+++ b/packages/oauth2/src/token-dpop/verify-token-dpop.ts
@@ -69,7 +69,7 @@ export interface VerifyTokenDPoPOptions {
 
 export async function verifyTokenDPoP(options: VerifyTokenDPoPOptions) {
   const { header, payload } = decodeJwt({
-    errorMessagePrefix: "Error decoding DPoP JWT:",
+    errorMessagePrefix: "Error decoding access token DPoP JWT:",
     headerSchema: zDpopJwtHeader,
     jwt: options.dpopJwt,
     payloadSchema: zDpopJwtPayload,

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -171,7 +171,10 @@ function parseProofJwt(options: {
   itWalletSpecsVersion: ItWalletSpecsVersion.V1_0 | ItWalletSpecsVersion.V1_3;
   jwt: string;
 }): ParsedCredentialProof {
-  const decoded = decodeJwt({ jwt: options.jwt });
+  const decoded = decodeJwt({
+    errorMessagePrefix: "Error decoding credential request proof JWT:",
+    jwt: options.jwt,
+  });
   const headerValidation =
     options.itWalletSpecsVersion === ItWalletSpecsVersion.V1_3
       ? zProofJwtHeaderV1_3.safeParse(decoded.header)

--- a/packages/oid4vci/src/credential-request/verify-credential-request-jwt-proof.ts
+++ b/packages/oid4vci/src/credential-request/verify-credential-request-jwt-proof.ts
@@ -220,6 +220,7 @@ export async function verifyCredentialRequestJwtProof(
 
     if (hasConfigVersion(options, ItWalletSpecsVersion.V1_0)) {
       const { header, payload } = decodeJwt({
+        errorMessagePrefix: "Error decoding credential request proof JWT:",
         headerSchema: zProofJwtHeaderV1_0,
         jwt: options.jwt,
         payloadSchema: zProofJwtPayload,
@@ -249,6 +250,7 @@ export async function verifyCredentialRequestJwtProof(
 
     if (hasConfigVersion(options, ItWalletSpecsVersion.V1_3)) {
       const { header, payload } = decodeJwt({
+        errorMessagePrefix: "Error decoding credential request proof JWT:",
         headerSchema: zProofJwtHeaderV1_3,
         jwt: options.jwt,
         payloadSchema: zProofJwtPayload,

--- a/packages/oid4vci/src/credential-request/verify-key-attestation-jwt.ts
+++ b/packages/oid4vci/src/credential-request/verify-key-attestation-jwt.ts
@@ -80,6 +80,7 @@ export async function verifyKeyAttestationJwt(
 ): Promise<VerifyKeyAttestationJwtResult> {
   try {
     const { header, payload } = decodeJwt({
+      errorMessagePrefix: "Error decoding key attestation JWT:",
       headerSchema: zKeyAttestationHeader,
       jwt: options.keyAttestationJwt,
       payloadSchema: zKeyAttestationPayload,

--- a/packages/oid4vci/src/metadata/fetch-metadata.ts
+++ b/packages/oid4vci/src/metadata/fetch-metadata.ts
@@ -87,6 +87,7 @@ async function tryFederationDiscovery(
 
     const entityStatement = await response.text();
     const { header, payload } = decodeJwt({
+      errorMessagePrefix: "Error decoding entity statement JWT:",
       jwt: entityStatement,
       payloadSchema: itWalletEntityStatementClaimsSchema,
     });

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -162,6 +162,7 @@ export async function parseAuthorizeRequest(
       : zOpenid4vpAuthorizationRequestHeaderV1_3;
 
     const decoded = decodeJwt({
+      errorMessagePrefix: "Error decoding authorization request JWT:",
       headerSchema,
       jwt: options.requestObjectJwt,
       payloadSchema: zOpenid4vpAuthorizationRequestPayload,

--- a/packages/oid4vp/src/jarm/verify-jarm-authorization-response.ts
+++ b/packages/oid4vp/src/jarm/verify-jarm-authorization-response.ts
@@ -158,6 +158,7 @@ export async function verifyJarmAuthorizationResponse(
 
   if (responseIsSigned) {
     const { header: jwsProtectedHeader, payload: jwsPayload } = decodeJwt({
+      errorMessagePrefix: "Error decoding JARM authorization response JWT:",
       headerSchema: z.object({ ...zJwtHeader.shape, kid: z.string() }),
       jwt: decryptedRequestData.payload,
     });

--- a/packages/utils/src/parse.ts
+++ b/packages/utils/src/parse.ts
@@ -39,3 +39,7 @@ export function parseWithErrorHandling<Schema extends BaseSchema>(
 
   return parseResult.data;
 }
+
+export function formatError(message: string, prefix?: string): string {
+  return prefix ? `${prefix} ${message}` : message;
+}


### PR DESCRIPTION
#### List of Changes
- Introduced optional error message prefixes for various JWT decoding functions to enhance error reporting.
- Updated multiple files to include specific error messages for different JWT types, improving clarity when decoding errors occur.

#### Motivation and Context
This change improves the debugging process by providing more informative error messages when JWT decoding fails. It addresses the need for clearer context in error reporting, which can aid developers in identifying issues more efficiently.

#### How Has This Been Tested?
Changes were tested by running existing unit tests and verifying that the new error messages appear correctly during JWT decoding failures. The testing environment included the latest version of the development framework and relevant dependencies.

