### PR TITLE
fix(oauth2): [WLEO-1082] use IT-Wallet authorization server metadata types

### DIFF
--- a/.changeset/giant-trams-own.md
+++ b/.changeset/giant-trams-own.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oauth2": patch
+---
+
+fix(oauth2): use IT-Wallet authorization metadata types

--- a/packages/oauth2/package.json
+++ b/packages/oauth2/package.json
@@ -30,6 +30,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@pagopa/io-wallet-oid-federation": "workspace:*",
     "@pagopa/io-wallet-utils": "workspace:*",
     "@openid4vc/oauth2": "catalog:",
     "@openid4vc/utils": "catalog:",

--- a/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
+++ b/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable max-lines-per-function */
-import {
-  AuthorizationServerMetadata,
-  CallbackContext,
-} from "@openid4vc/oauth2";
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
+import { CallbackContext } from "@openid4vc/oauth2";
 import {
   IoWalletSdkConfig,
   ItWalletSpecsVersion,
@@ -47,7 +46,7 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
 
   const mockAuthorizationServerMetadata = {
     issuer: "https://auth.example.com",
-  } as AuthorizationServerMetadata;
+  } as ItWalletAuthorizationServerMetadata;
 
   const mockConfig = new IoWalletSdkConfig({
     itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,

--- a/packages/oauth2/src/access-token/verify-access-token-request.ts
+++ b/packages/oauth2/src/access-token/verify-access-token-request.ts
@@ -1,7 +1,6 @@
-import {
-  AuthorizationServerMetadata,
-  CallbackContext,
-} from "@openid4vc/oauth2";
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
+import { CallbackContext } from "@openid4vc/oauth2";
 import { IoWalletSdkConfig, RequestLike } from "@pagopa/io-wallet-utils";
 
 import {
@@ -46,7 +45,7 @@ export interface VerifyAccessTokenRequestOptions {
   /**
    * The authorization server metadata
    */
-  authorizationServerMetadata: AuthorizationServerMetadata;
+  authorizationServerMetadata: ItWalletAuthorizationServerMetadata;
 
   /**
    * Callbacks used during verification

--- a/packages/oauth2/src/authorization-request/__tests__/verify-authorization-request.test.ts
+++ b/packages/oauth2/src/authorization-request/__tests__/verify-authorization-request.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable max-lines-per-function */
-import {
-  AuthorizationServerMetadata,
-  CallbackContext,
-} from "@openid4vc/oauth2";
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
+import { CallbackContext } from "@openid4vc/oauth2";
 import {
   IoWalletSdkConfig,
   ItWalletSpecsVersion,
@@ -46,7 +45,7 @@ describe("verifyAuthorizationRequest", () => {
 
   const mockAuthorizationServerMetadata = {
     issuer: "https://auth.example.com",
-  } as AuthorizationServerMetadata;
+  } as ItWalletAuthorizationServerMetadata;
 
   const mockConfig = new IoWalletSdkConfig({
     itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,

--- a/packages/oauth2/src/authorization-request/__tests__/verify-pushed-authorization-request.test.ts
+++ b/packages/oauth2/src/authorization-request/__tests__/verify-pushed-authorization-request.test.ts
@@ -1,9 +1,7 @@
 /* eslint-disable max-lines-per-function */
-import {
-  AuthorizationServerMetadata,
-  CallbackContext,
-  JwtSigner,
-} from "@openid4vc/oauth2";
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
+import { CallbackContext, JwtSigner } from "@openid4vc/oauth2";
 import {
   IoWalletSdkConfig,
   ItWalletSpecsVersion,
@@ -51,7 +49,7 @@ describe("verifyPushedAuthorizationRequest", () => {
 
   const mockAuthorizationServerMetadata = {
     issuer: "https://auth.example.com",
-  } as AuthorizationServerMetadata;
+  } as ItWalletAuthorizationServerMetadata;
 
   const mockAuthorizationRequest = {
     client_id: "client-123",
@@ -352,7 +350,7 @@ describe("verifyPushedAuthorizationRequest", () => {
         authorizationServerMetadata: {
           ...mockAuthorizationServerMetadata,
           require_signed_request_object: false,
-        },
+        } as VerifyPushedAuthorizationRequestOptions["authorizationServerMetadata"],
         callbacks: mockCallbacks,
         clientAttestation: {
           clientAttestationPopJwt,

--- a/packages/oauth2/src/authorization-request/create-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/create-authorization-request.ts
@@ -1,8 +1,6 @@
-import {
-  AuthorizationServerMetadata,
-  CallbackContext,
-  RequestDpopOptions,
-} from "@openid4vc/oauth2";
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
+import { CallbackContext, RequestDpopOptions } from "@openid4vc/oauth2";
 import {
   addSecondsToDate,
   dateToSeconds,
@@ -55,7 +53,7 @@ export interface CreatePushedAuthorizationRequestOptions {
    */
   clientId: string;
 
-  codeChallengeMethodsSupported: AuthorizationServerMetadata["code_challenge_methods_supported"];
+  codeChallengeMethodsSupported: ItWalletAuthorizationServerMetadata["code_challenge_methods_supported"];
 
   /**
    * DPoP options. Required when `require_signed_request_object` is `true`

--- a/packages/oauth2/src/authorization-request/verify-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/verify-authorization-request.ts
@@ -1,7 +1,6 @@
-import {
-  AuthorizationServerMetadata,
-  CallbackContext,
-} from "@openid4vc/oauth2";
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
+import { CallbackContext } from "@openid4vc/oauth2";
 import { IoWalletSdkConfig, RequestLike } from "@pagopa/io-wallet-utils";
 
 import {
@@ -64,7 +63,7 @@ export interface VerifyAuthorizationRequestOptions {
     client_id?: string;
   };
 
-  authorizationServerMetadata: AuthorizationServerMetadata;
+  authorizationServerMetadata: ItWalletAuthorizationServerMetadata;
   callbacks: Pick<CallbackContext, "hash" | "verifyJwt">;
 
   clientAttestation: ClientAttestationOptions;

--- a/packages/oauth2/src/client-attestation/client-authentication.ts
+++ b/packages/oauth2/src/client-attestation/client-authentication.ts
@@ -1,7 +1,6 @@
-import {
-  AuthorizationServerMetadata,
-  CallbackContext,
-} from "@openid4vc/oauth2";
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
+import { CallbackContext } from "@openid4vc/oauth2";
 import { ContentType, FetchHeaders, HttpMethod } from "@pagopa/io-wallet-utils";
 
 import { createClientAttestationPopJwt } from "./client-attestation-pop";
@@ -31,7 +30,7 @@ export type SupportedClientAuthenticationMethod =
  */
 export interface IsClientAttestationSupportedOptions {
   /** Authorization server metadata containing supported authentication methods. */
-  authorizationServerMetadata: AuthorizationServerMetadata;
+  authorizationServerMetadata: ItWalletAuthorizationServerMetadata;
 }
 
 /**
@@ -67,7 +66,7 @@ export interface ClientAuthenticationCallbackOptions {
   /**
    * Metadata of the authorization server
    */
-  authorizationServerMetadata: AuthorizationServerMetadata;
+  authorizationServerMetadata: ItWalletAuthorizationServerMetadata;
 
   /**
    * The body as a JSON object. If content type `x-www-form-urlencoded`

--- a/packages/oauth2/src/client-attestation/verify-client-attestation.ts
+++ b/packages/oauth2/src/client-attestation/verify-client-attestation.ts
@@ -1,5 +1,6 @@
+import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-federation";
+
 import {
-  AuthorizationServerMetadata,
   CallbackContext,
   HashAlgorithm,
   calculateJwkThumbprint,
@@ -39,7 +40,7 @@ export interface VerifyClientAttestationOptions {
   /**
    * The authorization server metadata.
    */
-  authorizationServerMetadata: AuthorizationServerMetadata;
+  authorizationServerMetadata: ItWalletAuthorizationServerMetadata;
 
   /**
    * Callbacks for hashing and JWT verification.

--- a/packages/oid-federation/package.json
+++ b/packages/oid-federation/package.json
@@ -29,7 +29,6 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap"
   },
   "dependencies": {
-    "@pagopa/io-wallet-oauth2": "workspace:",
     "@pagopa/io-wallet-utils": "workspace:",
     "buffer": "catalog:",
     "zod": "catalog:"

--- a/packages/oid-federation/src/jwk/jwk.ts
+++ b/packages/oid-federation/src/jwk/jwk.ts
@@ -1,4 +1,3 @@
-import { zCertificateChain } from "@pagopa/io-wallet-oauth2";
 import { z } from "zod";
 
 export const jsonWebKeySchema = z.looseObject({
@@ -7,7 +6,7 @@ export const jsonWebKeySchema = z.looseObject({
   kid: z.string(),
   kty: z.string(),
   use: z.string().optional(),
-  x5c: zCertificateChain.optional(),
+  x5c: z.array(z.string()).nonempty().optional(),
   x5t: z.string().optional(),
   "x5t#S256": z.string().optional(),
   x5u: z.string().optional(),

--- a/packages/oid-federation/src/metadata/entity/index.ts
+++ b/packages/oid-federation/src/metadata/entity/index.ts
@@ -1,5 +1,25 @@
 export * from "./itWalletFederationEntity";
-export * from "./v1.0";
+
+export {
+  itWalletAuthorizationServerIdentifier,
+  itWalletAuthorizationServerMetadata,
+  itWalletCredentialIssuerIdentifier,
+  itWalletCredentialIssuerMetadata,
+  itWalletCredentialVerifierIdentifier,
+  itWalletCredentialVerifierMetadata,
+  itWalletProviderEntityIdentifier,
+  itWalletProviderEntityMetadata,
+} from "./v1.0";
+
+export type {
+  ClaimsMetadata,
+  CredentialDisplayMetadata,
+  ItWalletAuthorizationServerMetadata as ItWalletAuthorizationServerMetadataV1_0,
+  ItWalletCredentialIssuerMetadata,
+  ItWalletCredentialVerifierMetadata,
+  ItWalletProviderEntityMetadata,
+  SupportedCredentialMetadata,
+} from "./v1.0";
 
 // v1.3 exports with version suffixes for disambiguation
 export {

--- a/packages/oid-federation/src/metadata/entity/index.ts
+++ b/packages/oid-federation/src/metadata/entity/index.ts
@@ -28,3 +28,7 @@ export type {
   KeyStorageLevel as KeyStorageLevelV1_3,
   SupportedCredentialMetadata as SupportedCredentialMetadataV1_3,
 } from "./v1.3";
+
+export type ItWalletAuthorizationServerMetadata =
+  | import("./v1.0").ItWalletAuthorizationServerMetadata
+  | import("./v1.3").ItWalletAuthorizationServerMetadata;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
 
   packages/oid-federation:
     dependencies:
-      '@pagopa/io-wallet-oauth2':
-        specifier: 'workspace:'
-        version: link:../oauth2
       '@pagopa/io-wallet-utils':
         specifier: 'workspace:'
         version: link:../utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@openid4vc/utils':
         specifier: 'catalog:'
         version: 0.4.3
+      '@pagopa/io-wallet-oid-federation':
+        specifier: workspace:*
+        version: link:../oid-federation
       '@pagopa/io-wallet-utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
This pull request updates the OAuth2 package to use the IT-Wallet-specific authorization server metadata types throughout the codebase, replacing the more generic types from `@openid4vc/oauth2`. This change ensures better alignment with IT-Wallet specifications and improves type safety and maintainability. The update affects interfaces, implementation files, and related tests.

**Migration to IT-Wallet Metadata Types:**

* Replaced all usages of `AuthorizationServerMetadata` from `@openid4vc/oauth2` with `ItWalletAuthorizationServerMetadata` from `@pagopa/io-wallet-oid-federation` in source files, interfaces, and test mocks. This affects files such as `verify-access-token-request.ts`, `verify-authorization-request.ts`, `create-authorization-request.ts`, and `client-authentication.ts`. [[1]](diffhunk://#diff-394db3f64df3538d248d4f1594371adf9a2ca5c7154610600b18376fe620022aL1-R3) [[2]](diffhunk://#diff-394db3f64df3538d248d4f1594371adf9a2ca5c7154610600b18376fe620022aL49-R48) [[3]](diffhunk://#diff-3040d83565747ae02ddfd05b1171e2bc8f4a1efe8f098aed6db9ff0f14e1da12L1-R3) [[4]](diffhunk://#diff-3040d83565747ae02ddfd05b1171e2bc8f4a1efe8f098aed6db9ff0f14e1da12L67-R66) [[5]](diffhunk://#diff-095deb79e1a2e821a363a87824a9460e6e344ad4325c338bcda48d4bb61775e8L1-R3) [[6]](diffhunk://#diff-095deb79e1a2e821a363a87824a9460e6e344ad4325c338bcda48d4bb61775e8L58-R56) [[7]](diffhunk://#diff-47a88f881f474a495a3292fdb8d61df0cfd09f902dbafdc2e8e08317a26ba3d6L1-R3) [[8]](diffhunk://#diff-47a88f881f474a495a3292fdb8d61df0cfd09f902dbafdc2e8e08317a26ba3d6L34-R33) [[9]](diffhunk://#diff-47a88f881f474a495a3292fdb8d61df0cfd09f902dbafdc2e8e08317a26ba3d6L70-R69) [[10]](diffhunk://#diff-db9045270c54ddd64db8426288c52fc6bea82037ea4f773df031b7579ae192f2R1-L2) [[11]](diffhunk://#diff-db9045270c54ddd64db8426288c52fc6bea82037ea4f773df031b7579ae192f2L42-R43)

* Updated all affected test files to use the new `ItWalletAuthorizationServerMetadata` type for mock metadata, ensuring tests reflect the new type requirements. [[1]](diffhunk://#diff-7d04a06cd15595971ed56aef84369a9cb5fd31a5960e76f89abbb7f1ccdec03bL2-R4) [[2]](diffhunk://#diff-7d04a06cd15595971ed56aef84369a9cb5fd31a5960e76f89abbb7f1ccdec03bL50-R49) [[3]](diffhunk://#diff-314b1c707c4eba176ec022b82220222466dc9b1246cff45e7bbc3eb5a044ecc4L2-R4) [[4]](diffhunk://#diff-314b1c707c4eba176ec022b82220222466dc9b1246cff45e7bbc3eb5a044ecc4L49-R48) [[5]](diffhunk://#diff-cf72c9c46230cabccf47fa68832c59721b3b54c04b53635a830a793902d799adL2-R4) [[6]](diffhunk://#diff-cf72c9c46230cabccf47fa68832c59721b3b54c04b53635a830a793902d799adL54-R52) [[7]](diffhunk://#diff-cf72c9c46230cabccf47fa68832c59721b3b54c04b53635a830a793902d799adL355-R353)

**Dependency and Type Exports:**

* Added `@pagopa/io-wallet-oid-federation` as a dependency in `package.json` to provide access to the IT-Wallet metadata types.
* Exported the union type `ItWalletAuthorizationServerMetadata` from the oid-federation package, combining both v1.0 and v1.3 versions for compatibility.

**Changelog:**

* Added a changeset describing the patch update and the migration to IT-Wallet authorization metadata types.