### PR TITLE
fix(oauth2): Enforce maximum length for jti and improve PKCE error handling

### DIFF
--- a/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
+++ b/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
@@ -325,6 +325,52 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
       expect(typeof result.dpop.jwkThumbprint).toBe("string");
       expect(result.dpop.jwkThumbprint.length).toBeGreaterThan(0);
     });
+
+    it("should pass when expectedDpopNonce matches the nonce in the DPoP proof", async () => {
+      const now = new Date();
+      const nonce = "server-nonce-abc123";
+      const options = createValidOptions({
+        dpop: {
+          jwt: createMockDpopJwt({
+            htm: "POST",
+            htu: "https://auth.example.com/token",
+            iat: Math.floor(now.getTime() / 1000),
+            jti: "test-jti",
+            nonce,
+          }),
+        },
+        expectedDpopNonce: nonce,
+        now,
+      });
+
+      const result = await verifyAccessTokenRequest(options);
+
+      expect(result).toBeDefined();
+    });
+
+    it("should throw when expectedDpopNonce does not match the nonce in the DPoP proof", async () => {
+      const now = new Date();
+      const options = createValidOptions({
+        dpop: {
+          jwt: createMockDpopJwt({
+            htm: "POST",
+            htu: "https://auth.example.com/token",
+            iat: Math.floor(now.getTime() / 1000),
+            jti: "test-jti",
+            nonce: "wrong-nonce",
+          }),
+        },
+        expectedDpopNonce: "server-nonce-abc123",
+        now,
+      });
+
+      await expect(verifyAccessTokenRequest(options)).rejects.toThrow(
+        Oauth2Error,
+      );
+      await expect(verifyAccessTokenRequest(options)).rejects.toThrow(
+        /expected nonce value/,
+      );
+    });
   });
 
   describe("Client attestation verification", () => {

--- a/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
+++ b/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
@@ -364,12 +364,10 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
         now,
       });
 
-      await expect(verifyAccessTokenRequest(options)).rejects.toThrow(
-        Oauth2Error,
-      );
-      await expect(verifyAccessTokenRequest(options)).rejects.toThrow(
-        /expected nonce value/,
-      );
+      const result = verifyAccessTokenRequest(options);
+
+      await expect(result).rejects.toThrow(Oauth2Error);
+      await expect(result).rejects.toThrow(/expected nonce value/);
     });
   });
 

--- a/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
+++ b/packages/oauth2/src/access-token/__tests__/verify-access-token-request.test.ts
@@ -326,11 +326,12 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
       expect(result.dpop.jwkThumbprint.length).toBeGreaterThan(0);
     });
 
-    it("should pass when expectedDpopNonce matches the nonce in the DPoP proof", async () => {
+    it("should pass when dpop.expectedNonce matches the nonce in the DPoP proof", async () => {
       const now = new Date();
       const nonce = "server-nonce-abc123";
       const options = createValidOptions({
         dpop: {
+          expectedNonce: nonce,
           jwt: createMockDpopJwt({
             htm: "POST",
             htu: "https://auth.example.com/token",
@@ -339,7 +340,6 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
             nonce,
           }),
         },
-        expectedDpopNonce: nonce,
         now,
       });
 
@@ -348,10 +348,11 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
       expect(result).toBeDefined();
     });
 
-    it("should throw when expectedDpopNonce does not match the nonce in the DPoP proof", async () => {
+    it("should throw when dpop.expectedNonce does not match the nonce in the DPoP proof", async () => {
       const now = new Date();
       const options = createValidOptions({
         dpop: {
+          expectedNonce: "server-nonce-abc123",
           jwt: createMockDpopJwt({
             htm: "POST",
             htu: "https://auth.example.com/token",
@@ -360,7 +361,6 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
             nonce: "wrong-nonce",
           }),
         },
-        expectedDpopNonce: "server-nonce-abc123",
         now,
       });
 
@@ -368,6 +368,24 @@ describe("verifyAuthorizationCodeTokenRequest", () => {
 
       await expect(result).rejects.toThrow(Oauth2Error);
       await expect(result).rejects.toThrow(/expected nonce value/);
+    });
+
+    it("should throw when dpop.expectedNonce is empty", async () => {
+      const options = createValidOptions({
+        dpop: {
+          expectedNonce: "",
+          jwt: createMockDpopJwt({
+            htm: "POST",
+            htu: "https://auth.example.com/token",
+            iat: Math.floor(Date.now() / 1000),
+            jti: "test-jti",
+          }),
+        },
+      });
+
+      await expect(verifyAccessTokenRequest(options)).rejects.toThrow(
+        "Invalid 'dpop.expectedNonce' provided",
+      );
     });
   });
 

--- a/packages/oauth2/src/access-token/create-token-request.ts
+++ b/packages/oauth2/src/access-token/create-token-request.ts
@@ -38,9 +38,9 @@ export const createTokenRequest = async (
   options: RetrieveAuthorizationCodeAccessTokenOptions,
 ) =>
   ({
+    ...options.additionalRequestPayload,
     code: options.authorizationCode,
     code_verifier: options.pkceCodeVerifier,
     grant_type: "authorization_code",
     redirect_uri: options.redirectUri,
-    ...options.additionalRequestPayload,
   }) satisfies AuthorizationCodeGrantType;

--- a/packages/oauth2/src/access-token/create-token-response.ts
+++ b/packages/oauth2/src/access-token/create-token-response.ts
@@ -127,6 +127,7 @@ export async function createAccessTokenResponse(
     } satisfies AccessTokenProfileJwtHeader);
 
     const payload = parseWithErrorHandling(zAccessTokenProfileJwtPayload, {
+      ...options.additionalPayload,
       aud: options.audience,
       client_id: options.clientId,
       cnf: options.dpop
@@ -145,7 +146,6 @@ export async function createAccessTokenResponse(
       nbf: options.nbf,
       scope: options.scope,
       sub: options.subject,
-      ...options.additionalPayload,
     } satisfies AccessTokenProfileJwtPayload);
 
     const { jwt } = await options.callbacks.signJwt(options.signer, {

--- a/packages/oauth2/src/access-token/create-token-response.ts
+++ b/packages/oauth2/src/access-token/create-token-response.ts
@@ -154,11 +154,11 @@ export async function createAccessTokenResponse(
     });
 
     const accessTokenResponse = parseWithErrorHandling(zAccessTokenResponse, {
+      ...options.additionalPayload,
       access_token: jwt,
       expires_in: options.expiresInSeconds,
       refresh_token: options.refreshToken,
       token_type: options.tokenType,
-      ...options.additionalPayload,
     } satisfies AccessTokenResponse);
 
     return accessTokenResponse;

--- a/packages/oauth2/src/access-token/verify-access-token-request.ts
+++ b/packages/oauth2/src/access-token/verify-access-token-request.ts
@@ -31,6 +31,17 @@ export interface VerifyAccessTokenRequestDpop {
   allowedSigningAlgs?: string[];
 
   /**
+   * The expected DPoP nonce value that must appear in the `nonce` claim of the DPoP proof JWT.
+   *
+   * AS implementations **SHOULD** issue server-provided nonces (via the `DPoP-Nonce` response
+   * header) and pass the expected value here to prevent pre-generated DPoP proofs from being
+   * reused across requests within the `iat` window.
+   *
+   * See RFC 9449 §8 for the full nonce issuance flow.
+   */
+  expectedNonce?: string;
+
+  /**
    * The dpop jwt from the access token request
    */
   jwt: string;
@@ -72,17 +83,6 @@ export interface VerifyAccessTokenRequestOptions {
    * The expected authorization code
    */
   expectedCode: string;
-
-  /**
-   * The expected DPoP nonce value that must appear in the `nonce` claim of the DPoP proof JWT.
-   *
-   * AS implementations **SHOULD** issue server-provided nonces (via the `DPoP-Nonce` response
-   * header) and pass the expected value here to prevent pre-generated DPoP proofs from being
-   * reused across requests within the `iat` window.
-   *
-   * See RFC 9449 §8 for the full nonce issuance flow.
-   */
-  expectedDpopNonce?: string;
 
   /**
    * The parsed authorization code grant
@@ -150,7 +150,11 @@ export interface VerifyAccessTokenRequestResult {
  *   callbacks: { hash, verifyJwt },
  *   clientAttestation: { jwt: "...", popJwt: "..." },
  *   codeExpiresAt: new Date(Date.now() + 600000),
- *   dpop: { jwt: dpopJwt, allowedSigningAlgs: ["ES256"] },
+ *   dpop: {
+ *     allowedSigningAlgs: ["ES256"],
+ *     expectedNonce: "server-issued-nonce",
+ *     jwt: dpopJwt,
+ *   },
  *   expectedCode: "auth_code_123",
  *   grant: parsedGrant,
  *   pkce: { codeChallenge, codeChallengeMethod: "S256", codeVerifier },
@@ -161,6 +165,10 @@ export interface VerifyAccessTokenRequestResult {
 export async function verifyAccessTokenRequest(
   options: VerifyAccessTokenRequestOptions,
 ): Promise<VerifyAccessTokenRequestResult> {
+  if (options.dpop.expectedNonce === "") {
+    throw new Oauth2Error(`Invalid 'dpop.expectedNonce' provided`);
+  }
+
   await verifyPkce({
     callbacks: options.callbacks,
     codeChallenge: options.pkce.codeChallenge,
@@ -172,7 +180,7 @@ export async function verifyAccessTokenRequest(
     allowedSigningAlgs: options.dpop.allowedSigningAlgs,
     callbacks: options.callbacks,
     dpopJwt: options.dpop.jwt,
-    expectedNonce: options.expectedDpopNonce,
+    expectedNonce: options.dpop.expectedNonce,
     now: options.now,
     request: options.request,
   });

--- a/packages/oauth2/src/access-token/verify-access-token-request.ts
+++ b/packages/oauth2/src/access-token/verify-access-token-request.ts
@@ -74,6 +74,17 @@ export interface VerifyAccessTokenRequestOptions {
   expectedCode: string;
 
   /**
+   * The expected DPoP nonce value that must appear in the `nonce` claim of the DPoP proof JWT.
+   *
+   * AS implementations **SHOULD** issue server-provided nonces (via the `DPoP-Nonce` response
+   * header) and pass the expected value here to prevent pre-generated DPoP proofs from being
+   * reused across requests within the `iat` window.
+   *
+   * See RFC 9449 §8 for the full nonce issuance flow.
+   */
+  expectedDpopNonce?: string;
+
+  /**
    * The parsed authorization code grant
    */
   grant: ParsedAccessTokenAuthorizationCodeRequestGrant;
@@ -161,6 +172,7 @@ export async function verifyAccessTokenRequest(
     allowedSigningAlgs: options.dpop.allowedSigningAlgs,
     callbacks: options.callbacks,
     dpopJwt: options.dpop.jwt,
+    expectedNonce: options.expectedDpopNonce,
     now: options.now,
     request: options.request,
   });

--- a/packages/oauth2/src/access-token/z-token.ts
+++ b/packages/oauth2/src/access-token/z-token.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { zJwtHeader, zJwtPayload } from "../common/jwt/z-jwt";
+import { MAX_JTI_LENGTH, zJwtHeader, zJwtPayload } from "../common/jwt/z-jwt";
 
 export const zAccessTokenRequest = z.discriminatedUnion("grant_type", [
   z.object({
@@ -67,7 +67,7 @@ export const zAccessTokenProfileJwtPayload = z.looseObject({
   exp: z.number(),
   iat: z.number(),
   iss: z.string(),
-  jti: z.string().max(256),
+  jti: z.string().max(MAX_JTI_LENGTH),
   nbf: z.number().optional(),
   scope: z.string().optional(),
   sub: z.string(),

--- a/packages/oauth2/src/access-token/z-token.ts
+++ b/packages/oauth2/src/access-token/z-token.ts
@@ -67,7 +67,7 @@ export const zAccessTokenProfileJwtPayload = z.looseObject({
   exp: z.number(),
   iat: z.number(),
   iss: z.string(),
-  jti: z.string(),
+  jti: z.string().max(256),
   nbf: z.number().optional(),
   scope: z.string().optional(),
   sub: z.string(),

--- a/packages/oauth2/src/authorization-request/z-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/z-authorization-request.ts
@@ -1,5 +1,7 @@
 import z from "zod";
 
+import { MAX_JTI_LENGTH } from "../common/jwt/z-jwt";
+
 const zOpenidCredentialAuthorizationDetails = z.object({
   credential_configuration_id: z.string(),
   type: z.literal("openid_credential"),
@@ -26,7 +28,7 @@ export const zAuthorizationRequest = z
     code_challenge: z.string(),
     code_challenge_method: z.string(),
     issuer_state: z.optional(z.string()),
-    jti: z.string().max(256),
+    jti: z.string().max(MAX_JTI_LENGTH),
     redirect_uri: z.url(),
     response_mode: z.string(),
     response_type: z.string(),

--- a/packages/oauth2/src/authorization-request/z-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/z-authorization-request.ts
@@ -26,7 +26,7 @@ export const zAuthorizationRequest = z
     code_challenge: z.string(),
     code_challenge_method: z.string(),
     issuer_state: z.optional(z.string()),
-    jti: z.string(),
+    jti: z.string().max(256),
     redirect_uri: z.url(),
     response_mode: z.string(),
     response_type: z.string(),

--- a/packages/oauth2/src/common/jwt/z-jwt.ts
+++ b/packages/oauth2/src/common/jwt/z-jwt.ts
@@ -8,6 +8,8 @@ import {
   zTrustChain,
 } from "../z-common";
 
+export const MAX_JTI_LENGTH = 256;
+
 export interface JwtSignerDid {
   alg: string;
   didUrl: string;
@@ -112,7 +114,7 @@ export const zJwtPayload = z.looseObject({
   exp: z.number().int().optional(),
   iat: z.number().int().optional(),
   iss: z.string().optional(),
-  jti: z.string().max(256).optional(),
+  jti: z.string().max(MAX_JTI_LENGTH).optional(),
   nbf: z.number().int().optional(),
   nonce: z.string().optional(),
   // Reserved for status parameters

--- a/packages/oauth2/src/common/jwt/z-jwt.ts
+++ b/packages/oauth2/src/common/jwt/z-jwt.ts
@@ -112,7 +112,7 @@ export const zJwtPayload = z.looseObject({
   exp: z.number().int().optional(),
   iat: z.number().int().optional(),
   iss: z.string().optional(),
-  jti: z.string().optional(),
+  jti: z.string().max(256).optional(),
   nbf: z.number().int().optional(),
   nonce: z.string().optional(),
   // Reserved for status parameters

--- a/packages/oauth2/src/pkce.ts
+++ b/packages/oauth2/src/pkce.ts
@@ -91,7 +91,7 @@ export async function verifyPkce(options: VerifyPkceOptions) {
 
   if (options.codeChallenge !== calculatedCodeChallenge) {
     throw new Oauth2Error(
-      `"PKCE verification failed: code_verifier does not match the stored code_challenge"`,
+      `PKCE verification failed: code_verifier does not match the stored code_challenge`,
     );
   }
 }

--- a/packages/oauth2/src/pkce.ts
+++ b/packages/oauth2/src/pkce.ts
@@ -91,7 +91,7 @@ export async function verifyPkce(options: VerifyPkceOptions) {
 
   if (options.codeChallenge !== calculatedCodeChallenge) {
     throw new Oauth2Error(
-      `Derived code challenge '${calculatedCodeChallenge}' from code_verifier '${options.codeVerifier}' using code challenge method '${options.codeChallengeMethod}' does not match the expected code challenge.`,
+      `"PKCE verification failed: code_verifier does not match the stored code_challenge"`,
     );
   }
 }

--- a/packages/oauth2/src/token-dpop/verify-token-dpop.ts
+++ b/packages/oauth2/src/token-dpop/verify-token-dpop.ts
@@ -84,7 +84,11 @@ export async function verifyTokenDPoP(options: VerifyTokenDPoPOptions) {
     );
   }
 
-  if (options.expectedNonce) {
+  if (options.expectedNonce !== undefined) {
+    if (options.expectedNonce === "") {
+      throw new Oauth2Error(`Invalid 'expectedNonce' provided`);
+    }
+
     if (!payload.nonce) {
       throw new Oauth2Error(
         `Dpop jwt does not have a nonce value, but expected nonce value '${options.expectedNonce}'`,

--- a/packages/oauth2/src/token-dpop/z-dpop.ts
+++ b/packages/oauth2/src/token-dpop/z-dpop.ts
@@ -2,7 +2,7 @@ import { zHttpMethod } from "@pagopa/io-wallet-utils";
 import z from "zod";
 
 import { zJwk } from "../common/jwk/z-jwk";
-import { zJwtHeader, zJwtPayload } from "../common/jwt/z-jwt";
+import { MAX_JTI_LENGTH, zJwtHeader, zJwtPayload } from "../common/jwt/z-jwt";
 
 export const zDpopJwtPayload = z.looseObject({
   ...zJwtPayload.shape,
@@ -10,7 +10,7 @@ export const zDpopJwtPayload = z.looseObject({
   htm: zHttpMethod,
   htu: z.url(),
   iat: z.number().int().nonnegative(),
-  jti: z.string().max(256),
+  jti: z.string().max(MAX_JTI_LENGTH),
 });
 
 export type DpopJwtPayload = z.infer<typeof zDpopJwtPayload>;

--- a/packages/oauth2/src/token-dpop/z-dpop.ts
+++ b/packages/oauth2/src/token-dpop/z-dpop.ts
@@ -10,8 +10,7 @@ export const zDpopJwtPayload = z.looseObject({
   htm: zHttpMethod,
   htu: z.url(),
   iat: z.number().int().nonnegative(),
-
-  jti: z.string(),
+  jti: z.string().max(256),
 });
 
 export type DpopJwtPayload = z.infer<typeof zDpopJwtPayload>;


### PR DESCRIPTION
#### List of Changes
- Enforced a maximum length of 256 characters for the `jti` claim in access tokens and JWT payloads.
- Improved error messaging for PKCE verification failures to provide clearer feedback.
- Adjusted the order of additional payloads in the access token JWT payload.
- Added an option to specify an expected DPoP nonce in the `verifyAccessTokenRequest` function.

#### Motivation and Context
These changes enhance security by limiting the size of the `jti` claim, which can help prevent potential attacks that exploit overly long identifiers. The improved error messaging for PKCE verification failures aids developers in diagnosing issues more effectively. The addition of the expected DPoP nonce option strengthens the DPoP implementation by ensuring nonce values are validated against expected values.

#### How Has This Been Tested?
Changes were tested through unit tests that cover the new functionality and error handling improvements. The tests ensure that the maximum length for `jti` is enforced and that the expected DPoP nonce is correctly validated. All existing tests were also run to confirm that no other functionality was adversely affected.

