### PR TITLE
feat(oid-federation): [WLEO-1053] add versioned metadata parsers

### DIFF
--- a/packages/oid-federation/src/entityConfiguration/itWalletEntityConfigurationClaims.ts
+++ b/packages/oid-federation/src/entityConfiguration/itWalletEntityConfigurationClaims.ts
@@ -1,6 +1,12 @@
+import type { ItWalletSpecsVersion } from "@pagopa/io-wallet-utils";
 import type { z } from "zod";
 
-import { itWalletEntityStatementClaimsSchema } from "../entityStatement/itWalletEntityStatementClaims";
+import {
+  ItWalletEntityStatementClaimsByVersion,
+  isItWalletEntityStatementClaimsVersion,
+  itWalletEntityStatementClaimsSchema,
+  parseItWalletEntityStatementClaimsForVersion,
+} from "../entityStatement/itWalletEntityStatementClaims";
 
 export const itWalletEntityConfigurationClaimsSchema =
   itWalletEntityStatementClaimsSchema;
@@ -12,3 +18,13 @@ export type ItWalletEntityConfigurationClaimsOptions = z.input<
 export type ItWalletEntityConfigurationClaims = z.output<
   typeof itWalletEntityConfigurationClaimsSchema
 >;
+
+export type ItWalletEntityConfigurationClaimsByVersion<
+  V extends ItWalletSpecsVersion,
+> = ItWalletEntityStatementClaimsByVersion<V>;
+
+export const isItWalletEntityConfigurationClaimsVersion =
+  isItWalletEntityStatementClaimsVersion;
+
+export const parseItWalletEntityConfigurationClaimsForVersion =
+  parseItWalletEntityStatementClaimsForVersion;

--- a/packages/oid-federation/src/entityStatement/itWalletEntityStatementClaims.ts
+++ b/packages/oid-federation/src/entityStatement/itWalletEntityStatementClaims.ts
@@ -1,7 +1,16 @@
+import {
+  ItWalletSpecsVersion,
+  parseWithErrorHandling,
+} from "@pagopa/io-wallet-utils";
 import { z } from "zod";
 
 import { jsonWebKeySetSchema } from "../jwk/jwk";
-import { itWalletMetadataSchema } from "../metadata/itWalletMetadata";
+import {
+  ItWalletMetadataByVersion,
+  isItWalletMetadataVersion,
+  itWalletMetadataSchema,
+  parseItWalletMetadataForVersion,
+} from "../metadata/itWalletMetadata";
 import { metadataPolicySchema } from "../metadata/policy";
 import { constraintSchema } from "./z-constraint";
 import {
@@ -34,9 +43,9 @@ const baseSchema = z.object({
   trust_marks: z.array(trustMarkSchema).optional(),
 });
 
-type ItWalletEntityStatementClaimsOptions = z.input<typeof baseSchema>;
+type BaseEntityStatementClaimsOptions = z.input<typeof baseSchema>;
 
-type ItWalletEntityStatementClaims = z.output<typeof baseSchema>;
+type BaseEntityStatementClaims = z.output<typeof baseSchema>;
 
 const entityStatementClaimsSchema = baseSchema.loose().refine(
   (data) => {
@@ -52,6 +61,59 @@ const entityStatementClaimsSchema = baseSchema.loose().refine(
 
 // The explicit type annotation here is necessary to avoid this node exceeds the maximum length the compiler will serialize.
 export const itWalletEntityStatementClaimsSchema: z.ZodType<
-  ItWalletEntityStatementClaims,
-  ItWalletEntityStatementClaimsOptions
+  BaseEntityStatementClaims,
+  BaseEntityStatementClaimsOptions
 > = entityStatementClaimsSchema;
+
+export type ItWalletEntityStatementClaimsOptions = z.input<
+  typeof itWalletEntityStatementClaimsSchema
+>;
+
+export type ItWalletEntityStatementClaims = z.output<
+  typeof itWalletEntityStatementClaimsSchema
+>;
+
+type EntityStatementClaimsWithMetadata<TMetadata> = {
+  metadata?: TMetadata;
+} & Omit<ItWalletEntityStatementClaims, "metadata">;
+
+export type ItWalletEntityStatementClaimsByVersion<
+  V extends ItWalletSpecsVersion,
+> = EntityStatementClaimsWithMetadata<ItWalletMetadataByVersion<V>>;
+
+export function isItWalletEntityStatementClaimsVersion<
+  V extends ItWalletSpecsVersion,
+>(
+  claims: unknown,
+  version: V,
+): claims is ItWalletEntityStatementClaimsByVersion<V> {
+  const parsedClaims = itWalletEntityStatementClaimsSchema.safeParse(claims);
+
+  if (!parsedClaims.success) {
+    return false;
+  }
+
+  return (
+    parsedClaims.data.metadata === undefined ||
+    isItWalletMetadataVersion(parsedClaims.data.metadata, version)
+  );
+}
+
+export function parseItWalletEntityStatementClaimsForVersion<
+  V extends ItWalletSpecsVersion,
+>(claims: unknown, version: V): ItWalletEntityStatementClaimsByVersion<V> {
+  const parsedClaims = parseWithErrorHandling(
+    itWalletEntityStatementClaimsSchema,
+    claims,
+    "invalid entity statement claims provided",
+  );
+
+  if (parsedClaims.metadata === undefined) {
+    return parsedClaims as ItWalletEntityStatementClaimsByVersion<V>;
+  }
+
+  return {
+    ...parsedClaims,
+    metadata: parseItWalletMetadataForVersion(parsedClaims.metadata, version),
+  } as ItWalletEntityStatementClaimsByVersion<V>;
+}

--- a/packages/oid-federation/src/metadata/__tests__/itWalletMetadata.test.ts
+++ b/packages/oid-federation/src/metadata/__tests__/itWalletMetadata.test.ts
@@ -1,0 +1,107 @@
+import {
+  ItWalletSpecsVersion,
+  ItWalletSpecsVersionError,
+} from "@pagopa/io-wallet-utils";
+import { describe, expect, it } from "vitest";
+
+import {
+  isItWalletMetadataVersion,
+  parseItWalletMetadataForVersion,
+} from "../itWalletMetadata";
+
+const validV1_0Metadata = {
+  wallet_provider: {
+    jwks_uri: "https://wallet-provider.example.com/jwks.json",
+    signed_jwks_uri: "https://wallet-provider.example.com/signed-jwks.jwt",
+  },
+};
+
+const validV1_3Metadata = {
+  wallet_solution: {
+    logo_uri: "https://wallet-solution.example.com/logo.svg",
+    wallet_metadata: {
+      authorization_endpoint: "https://wallet-solution.example.com/authorize",
+      client_id_prefixes_supported: ["openid_federation"],
+      credential_offer_endpoint:
+        "https://wallet-solution.example.com/credential-offer",
+      request_object_signing_alg_values_supported: ["ES256"],
+      response_modes_supported: ["query"],
+      response_types_supported: ["vp_token"],
+      vp_formats_supported: {
+        "dc+sd-jwt": {},
+      },
+      wallet_name: "Example Wallet",
+    },
+  },
+};
+
+describe("isItWalletMetadataVersion", () => {
+  it("should identify valid v1.0 metadata", () => {
+    expect(
+      isItWalletMetadataVersion(validV1_0Metadata, ItWalletSpecsVersion.V1_0),
+    ).toBe(true);
+  });
+
+  it("should identify valid v1.3 metadata", () => {
+    expect(
+      isItWalletMetadataVersion(validV1_3Metadata, ItWalletSpecsVersion.V1_3),
+    ).toBe(true);
+  });
+
+  it("should reject metadata for a different supported version", () => {
+    expect(
+      isItWalletMetadataVersion(validV1_0Metadata, ItWalletSpecsVersion.V1_3),
+    ).toBe(false);
+    expect(
+      isItWalletMetadataVersion(validV1_3Metadata, ItWalletSpecsVersion.V1_0),
+    ).toBe(false);
+  });
+
+  it("should throw for an unsupported version", () => {
+    expect(() =>
+      isItWalletMetadataVersion(validV1_0Metadata, "9.9.9" as never),
+    ).toThrow(ItWalletSpecsVersionError);
+  });
+});
+
+describe("parseItWalletMetadataForVersion", () => {
+  it("should parse valid v1.0 metadata", () => {
+    expect(
+      parseItWalletMetadataForVersion(
+        validV1_0Metadata,
+        ItWalletSpecsVersion.V1_0,
+      ),
+    ).toEqual(validV1_0Metadata);
+  });
+
+  it("should parse valid v1.3 metadata", () => {
+    expect(
+      parseItWalletMetadataForVersion(
+        validV1_3Metadata,
+        ItWalletSpecsVersion.V1_3,
+      ),
+    ).toEqual(validV1_3Metadata);
+  });
+
+  it("should reject metadata for a different supported version", () => {
+    expect(() =>
+      parseItWalletMetadataForVersion(
+        validV1_0Metadata,
+        ItWalletSpecsVersion.V1_3,
+      ),
+    ).toThrow(/invalid v1\.3 metadata provided/);
+
+    expect(() =>
+      parseItWalletMetadataForVersion(
+        validV1_3Metadata,
+        ItWalletSpecsVersion.V1_0,
+      ),
+    ).toThrow(/invalid v1\.0 metadata provided/);
+  });
+
+  it("should throw for an unsupported version", () => {
+    expect(() =>
+      parseItWalletMetadataForVersion(validV1_0Metadata, "9.9.9" as never),
+    ).toThrow(ItWalletSpecsVersionError);
+  });
+});

--- a/packages/oid-federation/src/metadata/itWalletMetadata.ts
+++ b/packages/oid-federation/src/metadata/itWalletMetadata.ts
@@ -1,3 +1,8 @@
+import {
+  ItWalletSpecsVersion,
+  ItWalletSpecsVersionError,
+  parseWithErrorHandling,
+} from "@pagopa/io-wallet-utils";
 import { z } from "zod";
 
 import {
@@ -53,6 +58,57 @@ export const itWalletMetadataV1_3 = z.strictObject({
 export const itWalletMetadataSchema =
   itWalletMetadataV1_3.or(itWalletMetadataV1_0);
 
-export type MetadataV1_0 = z.input<typeof itWalletMetadataV1_0>;
-export type MetadataV1_3 = z.input<typeof itWalletMetadataV1_3>;
-export type Metadata = MetadataV1_0 | MetadataV1_3;
+export type ItWalletMetadataV1_0 = z.output<typeof itWalletMetadataV1_0>;
+export type ItWalletMetadataV1_3 = z.output<typeof itWalletMetadataV1_3>;
+export type ItWalletMetadata = ItWalletMetadataV1_0 | ItWalletMetadataV1_3;
+
+export type ItWalletMetadataByVersion<V extends ItWalletSpecsVersion> =
+  V extends ItWalletSpecsVersion.V1_0
+    ? ItWalletMetadataV1_0
+    : V extends ItWalletSpecsVersion.V1_3
+      ? ItWalletMetadataV1_3
+      : never;
+
+export function isItWalletMetadataVersion<V extends ItWalletSpecsVersion>(
+  metadata: unknown,
+  version: V,
+): metadata is ItWalletMetadataByVersion<V> {
+  switch (version) {
+    case ItWalletSpecsVersion.V1_0:
+      return itWalletMetadataV1_0.safeParse(metadata).success;
+    case ItWalletSpecsVersion.V1_3:
+      return itWalletMetadataV1_3.safeParse(metadata).success;
+    default:
+      throw new ItWalletSpecsVersionError(
+        "isItWalletMetadataVersion",
+        version,
+        [ItWalletSpecsVersion.V1_0, ItWalletSpecsVersion.V1_3],
+      );
+  }
+}
+
+export function parseItWalletMetadataForVersion<V extends ItWalletSpecsVersion>(
+  metadata: unknown,
+  version: V,
+): ItWalletMetadataByVersion<V> {
+  switch (version) {
+    case ItWalletSpecsVersion.V1_0:
+      return parseWithErrorHandling(
+        itWalletMetadataV1_0,
+        metadata,
+        "invalid v1.0 metadata provided",
+      ) as ItWalletMetadataByVersion<V>;
+    case ItWalletSpecsVersion.V1_3:
+      return parseWithErrorHandling(
+        itWalletMetadataV1_3,
+        metadata,
+        "invalid v1.3 metadata provided",
+      ) as ItWalletMetadataByVersion<V>;
+    default:
+      throw new ItWalletSpecsVersionError(
+        "parseItWalletMetadataForVersion",
+        version,
+        [ItWalletSpecsVersion.V1_0, ItWalletSpecsVersion.V1_3],
+      );
+  }
+}


### PR DESCRIPTION
This pull request introduces support for handling multiple versions of the IT Wallet metadata and entity statement claims throughout the codebase. The changes add new utility types and functions to validate and parse claims and metadata according to the specified IT Wallet specification version, improving type safety and extensibility for future versions.

**Versioned Metadata and Claims Handling:**

* Added generic types (`ItWalletMetadataByVersion`, `ItWalletEntityStatementClaimsByVersion`) and functions (`isItWalletMetadataVersion`, `parseItWalletMetadataForVersion`, `isItWalletEntityStatementClaimsVersion`, `parseItWalletEntityStatementClaimsForVersion`) to handle parsing and validation of IT Wallet metadata and entity statement claims by specification version, supporting both v1.0 and v1.3. [[1]](diffhunk://#diff-0c3ad0ce4265ee7875fa9d81052d66e64d63abf7f82f7e4a2f4fe2544a20904aR1-R5) [[2]](diffhunk://#diff-0c3ad0ce4265ee7875fa9d81052d66e64d63abf7f82f7e4a2f4fe2544a20904aL56-R114) [[3]](diffhunk://#diff-bfe964db3ef3b7dd8a2cfdea761326b4e00fc3f077dd8a506c0211f2695bfbc0R1-R13) [[4]](diffhunk://#diff-bfe964db3ef3b7dd8a2cfdea761326b4e00fc3f077dd8a506c0211f2695bfbc0L55-R119) [[5]](diffhunk://#diff-870b076d1b1c7529773cc9793886a65e08ce716c0717cf76e3f71f8fd89e2fe3R1-R9) [[6]](diffhunk://#diff-870b076d1b1c7529773cc9793886a65e08ce716c0717cf76e3f71f8fd89e2fe3R21-R30)

**Type and Schema Refactoring:**

* Refactored types and schemas in `itWalletEntityStatementClaims.ts` and `itWalletMetadata.ts` to use new versioned types and to improve clarity, including renaming and restructuring of options and output types. [[1]](diffhunk://#diff-bfe964db3ef3b7dd8a2cfdea761326b4e00fc3f077dd8a506c0211f2695bfbc0L37-R48) [[2]](diffhunk://#diff-bfe964db3ef3b7dd8a2cfdea761326b4e00fc3f077dd8a506c0211f2695bfbc0L55-R119) [[3]](diffhunk://#diff-0c3ad0ce4265ee7875fa9d81052d66e64d63abf7f82f7e4a2f4fe2544a20904aL56-R114)

**Dependency and Import Updates:**

* Updated imports across affected files to use the new versioned utility functions and types from `@pagopa/io-wallet-utils` and local modules. [[1]](diffhunk://#diff-870b076d1b1c7529773cc9793886a65e08ce716c0717cf76e3f71f8fd89e2fe3R1-R9) [[2]](diffhunk://#diff-bfe964db3ef3b7dd8a2cfdea761326b4e00fc3f077dd8a506c0211f2695bfbc0R1-R13) [[3]](diffhunk://#diff-0c3ad0ce4265ee7875fa9d81052d66e64d63abf7f82f7e4a2f4fe2544a20904aR1-R5)