### PR TITLE
Refine CredentialRequestV1_3 type with variadic tuple

### DIFF
--- a/.changeset/three-flowers-walk.md
+++ b/.changeset/three-flowers-walk.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid4vci": patch
+---
+
+fix: refine CredentialRequestV1_3 type to use variadic tuple

--- a/packages/oid4vci/src/credential-request/v1.3/create-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/v1.3/create-credential-request.ts
@@ -68,7 +68,9 @@ export const createCredentialRequest = async (
   try {
     const { maxBatchSize, signers } = options;
 
-    if (signers.length === 0) {
+    const [firstSigner, ...otherSigners] = signers;
+
+    if (!firstSigner) {
       throw new ValidationError("At least one signer is required");
     }
 
@@ -107,9 +109,9 @@ export const createCredentialRequest = async (
       }
     }
 
-    const proofJwts = await Promise.all(
-      signers.map((signer) =>
-        signJwt(signer, {
+    const createProofJwt = async (signer: JwtSignerJwk): Promise<string> =>
+      (
+        await signJwt(signer, {
           header: {
             alg: signer.alg,
             jwk: signer.publicJwk,
@@ -122,14 +124,18 @@ export const createCredentialRequest = async (
             iss: options.clientId,
             nonce: options.nonce,
           },
-        }),
-      ),
-    );
+        })
+      ).jwt;
+
+    const proofJwts: [string, ...string[]] = await Promise.all([
+      createProofJwt(firstSigner),
+      ...otherSigners.map(createProofJwt),
+    ]);
 
     return parseWithErrorHandling(zCredentialRequestV1_3, {
       credential_identifier: options.credential_identifier,
       proofs: {
-        jwt: proofJwts.map((proofJwt) => proofJwt.jwt), // Array for batch support
+        jwt: proofJwts,
       },
     } satisfies CredentialRequestV1_3);
   } catch (error) {

--- a/packages/oid4vci/src/credential-request/v1.3/z-credential.ts
+++ b/packages/oid4vci/src/credential-request/v1.3/z-credential.ts
@@ -12,8 +12,8 @@ import {
  */
 export const zCredentialRequestProofs = z.object({
   jwt: z
-    .array(z.string().min(1, "JWT must not be empty"))
-    .min(1, "At least one JWT proof is required"),
+    .tuple([z.string().min(1, "JWT must not be empty")])
+    .rest(z.string().min(1, "JWT must not be empty")),
 });
 
 export type CredentialRequestProofs = z.infer<typeof zCredentialRequestProofs>;

--- a/packages/oid4vci/src/credential-request/v1.3/z-credential.ts
+++ b/packages/oid4vci/src/credential-request/v1.3/z-credential.ts
@@ -5,15 +5,17 @@ import {
   zBaseCredentialRequest,
 } from "../z-base-credential-request";
 
+const zCredentialRequestProofJwt = z
+  .string()
+  .min(1, "JWT must not be empty in credential request proofs array");
+
 /**
  * Proofs object schema for v1.3
  * Contains an array of JWTs (supports batch issuance)
  * proof_type is implicit (determined by the property name)
  */
 export const zCredentialRequestProofs = z.object({
-  jwt: z
-    .tuple([z.string().min(1, "JWT must not be empty")])
-    .rest(z.string().min(1, "JWT must not be empty")),
+  jwt: z.tuple([zCredentialRequestProofJwt], zCredentialRequestProofJwt),
 });
 
 export type CredentialRequestProofs = z.infer<typeof zCredentialRequestProofs>;


### PR DESCRIPTION
This pull request refactors how credential request proofs are created and validated in the OID4VCI package to ensure at least one JWT proof is always present and to improve type safety. The main changes include updating the validation schema, restructuring the creation of proof JWTs, and simplifying the handling of signers.

Resolves WLEO-1089

**Validation and Type Safety Improvements:**

* Updated the `zCredentialRequestProofs` schema in `z-credential.ts` to use a variadic tuple for the `jwt` property, enforcing at least one JWT string in the array and improving type safety.

**Credential Request Creation Refactor:**

* Changed the logic in `create-credential-request.ts` to destructure the `signers` array, ensuring at least one signer is present and throwing a validation error if not.
* Refactored proof JWT creation by introducing a `createProofJwt` helper and using it to generate the first JWT and any additional ones, ensuring the result matches the updated schema. [[1]](diffhunk://#diff-cfd35e2f0b3a9d4eacd08ab37243ed834b527d8c26426cd66ee8c61c2173c10aL110-R114) [[2]](diffhunk://#diff-cfd35e2f0b3a9d4eacd08ab37243ed834b527d8c26426cd66ee8c61c2173c10aL125-R138)
* Updated the returned `jwt` array to match the new tuple type, ensuring compatibility with the validation schema.