### PR TITLE
fix(oauth2): remove response_mode from authorization request v1.3

### DIFF
--- a/.changeset/curly-carrots-draw.md
+++ b/.changeset/curly-carrots-draw.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oauth2": patch
+---
+
+fix(oauth2): remove response_mode from authorization request v1.3

--- a/.changeset/curly-carrots-draw.md
+++ b/.changeset/curly-carrots-draw.md
@@ -1,5 +1,5 @@
 ---
-"@pagopa/io-wallet-oauth2": patch
+"@pagopa/io-wallet-oauth2": minor
 ---
 
 fix(oauth2): remove response_mode from authorization request v1.3

--- a/packages/oauth2/src/authorization-request/__tests__/create-authorization-request.test.ts
+++ b/packages/oauth2/src/authorization-request/__tests__/create-authorization-request.test.ts
@@ -234,10 +234,11 @@ describe("createPushedAuthorizationRequest", () => {
   });
 
   it("should create a v1.3 request without response_mode", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { responseMode: _, ...baseWithoutResponseMode } = baseOptions;
     const options = {
-      ...baseOptions,
+      ...baseWithoutResponseMode,
       config: configV1_3,
-      responseMode: undefined,
     };
 
     const result = await createPushedAuthorizationRequest(options);
@@ -253,17 +254,6 @@ describe("createPushedAuthorizationRequest", () => {
       pkceCodeVerifier: "test-code-verifier",
       request: "test-jwt-token",
     });
-  });
-
-  it("should reject responseMode at compile time for v1.3 options", () => {
-    const options = {
-      ...baseOptions,
-      config: configV1_3,
-      responseMode: "form_post",
-      // @ts-expect-error responseMode was removed from v1.3 authorization requests.
-    } satisfies CreatePushedAuthorizationRequestOptions;
-
-    expect(options.responseMode).toBe("form_post");
   });
 });
 

--- a/packages/oauth2/src/authorization-request/__tests__/create-authorization-request.test.ts
+++ b/packages/oauth2/src/authorization-request/__tests__/create-authorization-request.test.ts
@@ -1,3 +1,7 @@
+import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+} from "@pagopa/io-wallet-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PkceCodeChallengeMethod, createPkce } from "../../pkce";
@@ -35,6 +39,14 @@ const mockCallbacks = {
   signJwt: vi.fn(),
 };
 
+const configV1_0 = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
+});
+
+const configV1_3 = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
+});
+
 const baseOptions: CreatePushedAuthorizationRequestOptions = {
   audience: "https://issuer.example.com",
   authorization_details: [
@@ -49,6 +61,7 @@ const baseOptions: CreatePushedAuthorizationRequestOptions = {
   callbacks: mockCallbacks,
   clientId: "test-client-id",
   codeChallengeMethodsSupported: ["S256"],
+  config: configV1_0,
   dpop: {
     signer: mockSigner,
   },
@@ -219,6 +232,39 @@ describe("createPushedAuthorizationRequest", () => {
       request: "test-jwt-token",
     });
   });
+
+  it("should create a v1.3 request without response_mode", async () => {
+    const options = {
+      ...baseOptions,
+      config: configV1_3,
+      responseMode: undefined,
+    };
+
+    const result = await createPushedAuthorizationRequest(options);
+
+    expect(mockCallbacks.signJwt).toHaveBeenCalledWith(mockSigner, {
+      header: expect.any(Object),
+      payload: expect.not.objectContaining({
+        response_mode: expect.anything(),
+      }),
+    });
+    expect(result).toEqual({
+      client_id: "test-client-id",
+      pkceCodeVerifier: "test-code-verifier",
+      request: "test-jwt-token",
+    });
+  });
+
+  it("should reject responseMode at compile time for v1.3 options", () => {
+    const options = {
+      ...baseOptions,
+      config: configV1_3,
+      responseMode: "form_post",
+      // @ts-expect-error responseMode was removed from v1.3 authorization requests.
+    } satisfies CreatePushedAuthorizationRequestOptions;
+
+    expect(options.responseMode).toBe("form_post");
+  });
 });
 
 describe("createPushedAuthorizationRequest - timestamp handling", () => {
@@ -363,6 +409,29 @@ describe("createPushedAuthorizationRequest - JAR signing policy", () => {
       authorizationRequest: expect.objectContaining({
         client_id: "test-client-id",
         response_type: "code",
+      }),
+      client_id: "test-client-id",
+      pkceCodeVerifier: "test-code-verifier",
+    });
+  });
+
+  it("should create unsigned v1.3 PAR without response_mode", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { dpop: _, responseMode: __, ...baseWithoutDpop } = baseOptions;
+    const options = {
+      ...baseWithoutDpop,
+      authorizationServerMetadata: {
+        require_signed_request_object: false,
+      },
+      config: configV1_3,
+    };
+
+    const result = await createPushedAuthorizationRequest(options);
+
+    expect(mockCallbacks.signJwt).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      authorizationRequest: expect.not.objectContaining({
+        response_mode: expect.anything(),
       }),
       client_id: "test-client-id",
       pkceCodeVerifier: "test-code-verifier",

--- a/packages/oauth2/src/authorization-request/__tests__/fetch-authorization-response.test.ts
+++ b/packages/oauth2/src/authorization-request/__tests__/fetch-authorization-response.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import {
   CONTENT_TYPES,
   HEADERS,
@@ -355,6 +356,60 @@ describe("fetchPushedAuthorizationResponse - unsigned PAR", () => {
       "https://auth-server.example.com/par",
       {
         body: expectedParams,
+        headers: {
+          [HEADERS.CONTENT_TYPE]: CONTENT_TYPES.FORM_URLENCODED,
+          [HEADERS.OAUTH_CLIENT_ATTESTATION]: "test-wallet-attestation-jwt",
+          [HEADERS.OAUTH_CLIENT_ATTESTATION_POP]:
+            "test-client-attestation-dpop-jwt",
+        },
+        method: "POST",
+      },
+    );
+  });
+
+  it("should send unsigned v1.3 request body without response_mode", async () => {
+    const mockResponse = {
+      json: vi.fn().mockResolvedValue({
+        expires_in: 60,
+        request_uri: "urn:ietf:params:oauth:request_uri:test-uri",
+      }),
+      status: 201,
+    };
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const unsignedOptions: fetchPushedAuthorizationResponseOptions = {
+      ...baseOptions,
+      pushedAuthorizationRequest: {
+        authorizationRequest: {
+          client_id: "test-client-id",
+          code_challenge: "test-code-challenge",
+          code_challenge_method: "S256",
+          jti: "test-jti",
+          redirect_uri: "https://client.example.com/callback",
+          response_type: "code",
+          scope: "openid",
+          state: "test-state",
+        },
+        client_id: "test-client-id",
+        pkceCodeVerifier: "test-pkce-code-verifier",
+      },
+    };
+
+    await fetchPushedAuthorizationResponse(unsignedOptions);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://auth-server.example.com/par",
+      {
+        body: new URLSearchParams({
+          client_id: "test-client-id",
+          code_challenge: "test-code-challenge",
+          code_challenge_method: "S256",
+          jti: "test-jti",
+          redirect_uri: "https://client.example.com/callback",
+          response_type: "code",
+          scope: "openid",
+          state: "test-state",
+        }),
         headers: {
           [HEADERS.CONTENT_TYPE]: CONTENT_TYPES.FORM_URLENCODED,
           [HEADERS.OAUTH_CLIENT_ATTESTATION]: "test-wallet-attestation-jwt",

--- a/packages/oauth2/src/authorization-request/__tests__/parse-pushed-authorization-request.test.ts
+++ b/packages/oauth2/src/authorization-request/__tests__/parse-pushed-authorization-request.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-lines-per-function */
 import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
   RequestLike,
   UnexpectedStatusCodeError,
 } from "@pagopa/io-wallet-utils";
@@ -10,6 +12,12 @@ import { parsePushedAuthorizationRequest } from "../parse-pushed-authorization-r
 
 describe("parsePushedAuthorizationRequest", () => {
   const mockFetch = vi.fn();
+  const configV1_0 = new IoWalletSdkConfig({
+    itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
+  });
+  const configV1_3 = new IoWalletSdkConfig({
+    itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
+  });
   const mockRequest: RequestLike = {
     headers: new Headers(),
     method: "POST",
@@ -42,6 +50,7 @@ describe("parsePushedAuthorizationRequest", () => {
       const result = await parsePushedAuthorizationRequest({
         authorizationRequest: baseAuthorizationRequest,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: mockRequest,
       });
 
@@ -65,11 +74,59 @@ describe("parsePushedAuthorizationRequest", () => {
       const result = await parsePushedAuthorizationRequest({
         authorizationRequest: authRequestWithScope,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: mockRequest,
       });
 
       expect(result.authorizationRequest).toEqual(authRequestWithScope);
       expect(result.authorizationRequestJwt).toBeUndefined();
+    });
+
+    it("should throw for v1.0 authorization request without response_mode", async () => {
+      const authRequestWithoutResponseMode = {
+        client_id: "test-client-id",
+        code_challenge: "test-challenge",
+        code_challenge_method: "S256",
+        jti: "test-jti",
+        redirect_uri: "https://client.example.com/callback",
+        response_type: "code",
+        scope: "openid profile",
+        state: "test-state",
+      };
+
+      await expect(
+        parsePushedAuthorizationRequest({
+          authorizationRequest: authRequestWithoutResponseMode,
+          callbacks: { fetch: mockFetch },
+          config: configV1_0,
+          request: mockRequest,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("should parse v1.3 authorization request without response_mode", async () => {
+      const authRequestWithoutResponseMode = {
+        client_id: "test-client-id",
+        code_challenge: "test-challenge",
+        code_challenge_method: "S256",
+        jti: "test-jti",
+        redirect_uri: "https://client.example.com/callback",
+        response_type: "code",
+        scope: "openid profile",
+        state: "test-state",
+      };
+
+      const result = await parsePushedAuthorizationRequest({
+        authorizationRequest: authRequestWithoutResponseMode,
+        callbacks: { fetch: mockFetch },
+        config: configV1_3,
+        request: mockRequest,
+      });
+
+      expect(result.authorizationRequest).toEqual(
+        authRequestWithoutResponseMode,
+      );
+      expect(result.authorizationRequest).not.toHaveProperty("response_mode");
     });
 
     it("should throw error for missing mandatory fields", async () => {
@@ -81,6 +138,7 @@ describe("parsePushedAuthorizationRequest", () => {
         parsePushedAuthorizationRequest({
           authorizationRequest: invalidRequest,
           callbacks: { fetch: mockFetch },
+          config: configV1_0,
           request: mockRequest,
         }),
       ).rejects.toThrow();
@@ -101,6 +159,7 @@ describe("parsePushedAuthorizationRequest", () => {
         parsePushedAuthorizationRequest({
           authorizationRequest: requestWithoutAuthDetailsOrScope,
           callbacks: { fetch: mockFetch },
+          config: configV1_0,
           request: mockRequest,
         }),
       ).rejects.toThrow();
@@ -120,12 +179,31 @@ describe("parsePushedAuthorizationRequest", () => {
       const result = await parsePushedAuthorizationRequest({
         authorizationRequest: jarRequest,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: mockRequest,
       });
 
       expect(result.authorizationRequest).toBeDefined();
       expect(result.authorizationRequestJwt).toBe(mockJwt);
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should parse a v1.3 JAR request without response_mode", async () => {
+      const mockJwt =
+        "eyJhbGciOiJFUzI1NiIsInR5cCI6Imp3dCJ9.eyJyZXNwb25zZV90eXBlIjoiY29kZSIsImNsaWVudF9pZCI6InRlc3QtY2xpZW50LWlkIiwiY29kZV9jaGFsbGVuZ2UiOiJ0ZXN0LWNoYWxsZW5nZSIsImNvZGVfY2hhbGxlbmdlX21ldGhvZCI6IlMyNTYiLCJyZWRpcmVjdF91cmkiOiJodHRwczovL2NsaWVudC5leGFtcGxlLmNvbS9jYWxsYmFjayIsInN0YXRlIjoidGVzdC1zdGF0ZSIsInNjb3BlIjoib3BlbmlkIiwianRpIjoidGVzdC1qdGkifQ.signature";
+
+      const result = await parsePushedAuthorizationRequest({
+        authorizationRequest: {
+          client_id: "test-client-id",
+          request: mockJwt,
+        },
+        callbacks: { fetch: mockFetch },
+        config: configV1_3,
+        request: mockRequest,
+      });
+
+      expect(result.authorizationRequest).not.toHaveProperty("response_mode");
+      expect(result.authorizationRequestJwt).toBe(mockJwt);
     });
 
     it("should parse a JAR request with request_uri parameter (by reference)", async () => {
@@ -146,6 +224,7 @@ describe("parsePushedAuthorizationRequest", () => {
       const result = await parsePushedAuthorizationRequest({
         authorizationRequest: jarRequest,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: mockRequest,
       });
 
@@ -172,6 +251,7 @@ describe("parsePushedAuthorizationRequest", () => {
         parsePushedAuthorizationRequest({
           authorizationRequest: jarRequest,
           callbacks: { fetch: mockFetch },
+          config: configV1_0,
           request: mockRequest,
         }),
       ).rejects.toThrow();
@@ -189,6 +269,7 @@ describe("parsePushedAuthorizationRequest", () => {
       const result = await parsePushedAuthorizationRequest({
         authorizationRequest: jarRequest,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: mockRequest,
       });
 
@@ -219,6 +300,7 @@ describe("parsePushedAuthorizationRequest", () => {
       const promise = parsePushedAuthorizationRequest({
         authorizationRequest: jarRequest,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: mockRequest,
       });
 
@@ -239,6 +321,7 @@ describe("parsePushedAuthorizationRequest", () => {
         parsePushedAuthorizationRequest({
           authorizationRequest: invalidRequest,
           callbacks: { fetch: mockFetch },
+          config: configV1_0,
           request: mockRequest,
         }),
       ).rejects.toThrow();
@@ -258,6 +341,7 @@ describe("parsePushedAuthorizationRequest", () => {
         parsePushedAuthorizationRequest({
           authorizationRequest: baseAuthorizationRequest,
           callbacks: { fetch: mockFetch },
+          config: configV1_0,
           request: requestWithInvalidDpop,
         }),
       ).rejects.toThrow(Oauth2Error);
@@ -274,6 +358,7 @@ describe("parsePushedAuthorizationRequest", () => {
         parsePushedAuthorizationRequest({
           authorizationRequest: jarRequest,
           callbacks: { fetch: mockFetch },
+          config: configV1_0,
           request: mockRequest,
         }),
       ).rejects.toThrow(Oauth2Error);
@@ -309,6 +394,7 @@ describe("parsePushedAuthorizationRequest", () => {
       const result = await parsePushedAuthorizationRequest({
         authorizationRequest: jarRequest,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: requestWithHeaders,
       });
 
@@ -331,6 +417,7 @@ describe("parsePushedAuthorizationRequest", () => {
       const result = await parsePushedAuthorizationRequest({
         authorizationRequest: fullAuthRequest,
         callbacks: { fetch: mockFetch },
+        config: configV1_0,
         request: mockRequest,
       });
 

--- a/packages/oauth2/src/authorization-request/create-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/create-authorization-request.ts
@@ -2,6 +2,9 @@ import type { ItWalletAuthorizationServerMetadata } from "@pagopa/io-wallet-oid-
 
 import { CallbackContext, RequestDpopOptions } from "@openid4vc/oauth2";
 import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+  ItWalletSpecsVersionError,
   addSecondsToDate,
   dateToSeconds,
   encodeToBase64Url,
@@ -11,16 +14,22 @@ import { PushedAuthorizationRequestError } from "../errors";
 import { createPkce } from "../pkce";
 import {
   AuthorizationRequest,
+  AuthorizationRequestV1_0,
+  AuthorizationRequestV1_3,
   PushedAuthorizationRequest,
   PushedAuthorizationRequestSigned,
-  PushedAuthorizationRequestUnsigned,
-  zAuthorizationRequest,
+  PushedAuthorizationRequestUnsignedV1_0,
+  PushedAuthorizationRequestUnsignedV1_3,
+  zAuthorizationRequestV1_0,
+  zAuthorizationRequestV1_3,
 } from "./z-authorization-request";
 
 const JWT_EXPIRY_SECONDS = 3600; // 1 hour
 const RANDOM_BYTES_SIZE = 32;
 
-export interface CreatePushedAuthorizationRequestOptions {
+interface BaseCreatePushedAuthorizationRequestOptions<
+  V extends ItWalletSpecsVersion,
+> {
   /**
    * It MUST be set to the identifier of the Credential Issuer.
    */
@@ -55,6 +64,8 @@ export interface CreatePushedAuthorizationRequestOptions {
 
   codeChallengeMethodsSupported: ItWalletAuthorizationServerMetadata["code_challenge_methods_supported"];
 
+  config: IoWalletSdkConfig<V>;
+
   /**
    * DPoP options. Required when `require_signed_request_object` is `true`
    * (enforced at the type level via function overloads). Not used in the
@@ -88,11 +99,6 @@ export interface CreatePushedAuthorizationRequestOptions {
   redirectUri: string;
 
   /**
-   * It MUST be one of the supported values (response_modes_supported) provided in the metadata of the Credential Issuer.
-   */
-  responseMode: string;
-
-  /**
    * Scope to request for the authorization request
    */
   scope?: string;
@@ -102,6 +108,36 @@ export interface CreatePushedAuthorizationRequestOptions {
    */
   state?: string;
 }
+
+export interface CreatePushedAuthorizationRequestOptionsV1_0
+  extends BaseCreatePushedAuthorizationRequestOptions<ItWalletSpecsVersion.V1_0> {
+  /**
+   * It MUST be one of the supported values (response_modes_supported) provided in the metadata of the Credential Issuer.
+   */
+  responseMode: string;
+}
+
+export interface CreatePushedAuthorizationRequestOptionsV1_3
+  extends BaseCreatePushedAuthorizationRequestOptions<ItWalletSpecsVersion.V1_3> {
+  responseMode?: never;
+}
+
+export type CreatePushedAuthorizationRequestOptions =
+  | CreatePushedAuthorizationRequestOptionsV1_0
+  | CreatePushedAuthorizationRequestOptionsV1_3;
+
+type CreatePushedAuthorizationRequestOptionsSigned<
+  TOptions extends CreatePushedAuthorizationRequestOptions,
+> = {
+  authorizationServerMetadata: { require_signed_request_object: true };
+  dpop: RequestDpopOptions;
+} & TOptions;
+
+type CreatePushedAuthorizationRequestOptionsUnsigned<
+  TOptions extends CreatePushedAuthorizationRequestOptions,
+> = {
+  authorizationServerMetadata: { require_signed_request_object: false };
+} & TOptions;
 
 /**
  * Creates a Pushed Authorization Request (PAR) for OAuth 2.0 authorization flows.
@@ -135,7 +171,8 @@ export interface CreatePushedAuthorizationRequestOptions {
  * @param options.jti - Optional JWT ID for PAR (auto-generated if not provided)
  * @param options.pkceCodeVerifier - Optional PKCE code verifier (auto-generated if not provided)
  * @param options.redirectUri - Redirect URI for the authorization response
- * @param options.responseMode - Response mode (must be supported by Credential Issuer)
+ * @param options.config - Italian Wallet specification version used to build the request shape
+ * @param options.responseMode - Response mode (v1.0 only, must be supported by Credential Issuer)
  * @param options.scope - OAuth 2.0 scope to request
  * @param options.state - Optional state parameter (auto-generated if not provided)
  * @param options.expiresAt - Optional JWT expiration time (defaults to 1 hour from issuedAt)
@@ -202,34 +239,43 @@ export interface CreatePushedAuthorizationRequestOptions {
  */
 // Function overloads for type narrowing based on require_signed_request_object
 export async function createPushedAuthorizationRequest(
-  options: {
-    authorizationServerMetadata: { require_signed_request_object: true };
-    dpop: RequestDpopOptions;
-  } & CreatePushedAuthorizationRequestOptions,
+  options: CreatePushedAuthorizationRequestOptionsSigned<CreatePushedAuthorizationRequestOptions>,
 ): Promise<PushedAuthorizationRequestSigned>;
 
 export async function createPushedAuthorizationRequest(
-  options: {
-    authorizationServerMetadata: { require_signed_request_object: false };
-  } & CreatePushedAuthorizationRequestOptions,
-): Promise<PushedAuthorizationRequestUnsigned>;
+  options: CreatePushedAuthorizationRequestOptionsUnsigned<CreatePushedAuthorizationRequestOptionsV1_0>,
+): Promise<PushedAuthorizationRequestUnsignedV1_0>;
+
+export async function createPushedAuthorizationRequest(
+  options: CreatePushedAuthorizationRequestOptionsV1_0,
+): Promise<
+  PushedAuthorizationRequestSigned | PushedAuthorizationRequestUnsignedV1_0
+>;
+
+export async function createPushedAuthorizationRequest(
+  options: CreatePushedAuthorizationRequestOptionsUnsigned<CreatePushedAuthorizationRequestOptionsV1_3>,
+): Promise<PushedAuthorizationRequestUnsignedV1_3>;
+
+export async function createPushedAuthorizationRequest(
+  options: CreatePushedAuthorizationRequestOptionsV1_3,
+): Promise<
+  PushedAuthorizationRequestSigned | PushedAuthorizationRequestUnsignedV1_3
+>;
 
 export async function createPushedAuthorizationRequest(
   options: CreatePushedAuthorizationRequestOptions,
 ): Promise<PushedAuthorizationRequest>;
 
-// Implementation
 export async function createPushedAuthorizationRequest(
   options: CreatePushedAuthorizationRequestOptions,
 ): Promise<PushedAuthorizationRequest> {
-  // PKCE
   const pkce = await createPkce({
     allowedCodeChallengeMethods: options.codeChallengeMethodsSupported,
     callbacks: options.callbacks,
     codeVerifier: options.pkceCodeVerifier,
   });
 
-  const authorizationRequest = zAuthorizationRequest.parse({
+  const baseAuthorizationRequest = {
     authorization_details: options.authorization_details,
     client_id: options.clientId,
     code_challenge: pkce.codeChallenge,
@@ -240,7 +286,6 @@ export async function createPushedAuthorizationRequest(
         await options.callbacks.generateRandom(RANDOM_BYTES_SIZE),
       ),
     redirect_uri: options.redirectUri,
-    response_mode: options.responseMode,
     response_type: "code",
     scope: options.scope,
     state:
@@ -248,14 +293,17 @@ export async function createPushedAuthorizationRequest(
       encodeToBase64Url(
         await options.callbacks.generateRandom(RANDOM_BYTES_SIZE),
       ),
-  });
+  };
 
-  // Check if JAR signing is required
+  const authorizationRequest = parseAuthorizationRequestByVersion(
+    options,
+    baseAuthorizationRequest,
+  );
+
   const requireSigned =
     options.authorizationServerMetadata?.require_signed_request_object ?? false;
 
   if (requireSigned) {
-    // Create signed JAR (JWT-Secured Authorization Request)
     const { dpop } = options;
     if (!dpop || !dpop.signer.alg || !dpop.signer.publicJwk?.kid) {
       throw new PushedAuthorizationRequestError(
@@ -285,12 +333,41 @@ export async function createPushedAuthorizationRequest(
       pkceCodeVerifier: pkce.codeVerifier,
       request: requestJwt.jwt,
     };
-  } else {
-    // Create unsigned authorization request
-    return {
-      authorizationRequest,
-      client_id: options.clientId,
-      pkceCodeVerifier: pkce.codeVerifier,
-    };
   }
+
+  return {
+    authorizationRequest,
+    client_id: options.clientId,
+    pkceCodeVerifier: pkce.codeVerifier,
+  };
+}
+
+function parseAuthorizationRequestByVersion(
+  options: CreatePushedAuthorizationRequestOptions,
+  baseAuthorizationRequest: Omit<
+    AuthorizationRequest,
+    "authorization_details" | "response_mode" | "scope"
+  > &
+    Pick<AuthorizationRequest, "authorization_details" | "scope">,
+): AuthorizationRequest {
+  const version = options.config.itWalletSpecsVersion;
+
+  if (version === ItWalletSpecsVersion.V1_0) {
+    return zAuthorizationRequestV1_0.parse({
+      ...baseAuthorizationRequest,
+      response_mode: options.responseMode,
+    }) satisfies AuthorizationRequestV1_0;
+  }
+
+  if (version === ItWalletSpecsVersion.V1_3) {
+    return zAuthorizationRequestV1_3.parse(
+      baseAuthorizationRequest,
+    ) satisfies AuthorizationRequestV1_3;
+  }
+
+  throw new ItWalletSpecsVersionError(
+    "createPushedAuthorizationRequest",
+    version,
+    [ItWalletSpecsVersion.V1_0, ItWalletSpecsVersion.V1_3],
+  );
 }

--- a/packages/oauth2/src/authorization-request/create-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/create-authorization-request.ts
@@ -187,12 +187,17 @@ type CreatePushedAuthorizationRequestOptionsUnsigned<
  * @throws {ZodError} If authorization request parameters fail validation
  *
  * @example
- * // Example 1: Create signed PAR (explicit)
+ * // Example 1: Create signed PAR for IT-Wallet v1.0 (explicit)
+ * const config = new IoWalletSdkConfig({
+ *   itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
+ * });
+ *
  * const signedPar = await createPushedAuthorizationRequest({
  *   audience: 'https://issuer.example.com',
  *   callbacks: { generateRandom, hash, signJwt },
  *   clientId: 'wallet_client_thumbprint',
  *   codeChallengeMethodsSupported: ['S256'],
+ *   config,
  *   dpop: { signer: { alg: 'ES256', publicJwk: { kid: 'key-1' } } },
  *   redirectUri: 'https://wallet.example.com/callback',
  *   responseMode: 'form_post.jwt',
@@ -204,14 +209,18 @@ type CreatePushedAuthorizationRequestOptionsUnsigned<
  * // signedPar.request contains the signed JWT
  *
  * @example
- * // Example 2: Create unsigned PAR (when Authorization Server allows it)
+ * // Example 2: Create unsigned PAR for IT-Wallet v1.3 (when Authorization Server allows it)
+ * const config = new IoWalletSdkConfig({
+ *   itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
+ * });
+ *
  * const unsignedPar = await createPushedAuthorizationRequest({
  *   audience: 'https://issuer.example.com',
  *   callbacks: { generateRandom, hash, signJwt },
  *   clientId: 'wallet_client_thumbprint',
  *   codeChallengeMethodsSupported: ['S256'],
+ *   config,
  *   redirectUri: 'https://wallet.example.com/callback',
- *   responseMode: 'query',
  *   scope: 'openid',
  *   authorizationServerMetadata: {
  *     require_signed_request_object: false  // Creates unsigned request — dpop not needed
@@ -220,12 +229,17 @@ type CreatePushedAuthorizationRequestOptionsUnsigned<
  * // unsignedPar.authorizationRequest contains the plain object
  *
  * @example
- * // Example 3: Default behavior (no metadata - unsigned)
+ * // Example 3: Default behavior for IT-Wallet v1.0 (no metadata - unsigned)
+ * const config = new IoWalletSdkConfig({
+ *   itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
+ * });
+ *
  * const par = await createPushedAuthorizationRequest({
  *   audience: 'https://issuer.example.com',
  *   callbacks: { generateRandom, hash, signJwt },
  *   clientId: 'wallet_client_thumbprint',
  *   codeChallengeMethodsSupported: ['S256'],
+ *   config,
  *   redirectUri: 'https://wallet.example.com/callback',
  *   responseMode: 'form_post.jwt',
  *   scope: 'openid'

--- a/packages/oauth2/src/authorization-request/create-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/create-authorization-request.ts
@@ -14,7 +14,6 @@ import {
 import { PushedAuthorizationRequestError } from "../errors";
 import { createPkce } from "../pkce";
 import {
-  AuthorizationRequest,
   AuthorizationRequestV1_0,
   AuthorizationRequestV1_3,
   PushedAuthorizationRequest,
@@ -27,6 +26,8 @@ import {
 
 const JWT_EXPIRY_SECONDS = 3600; // 1 hour
 const RANDOM_BYTES_SIZE = 32;
+
+type AuthorizationRequest = AuthorizationRequestV1_0 | AuthorizationRequestV1_3;
 
 interface BaseCreatePushedAuthorizationRequestOptions<
   V extends ItWalletSpecsVersion,
@@ -179,7 +180,7 @@ type CreatePushedAuthorizationRequestOptionsUnsigned<
  *
  * @returns A promise resolving to either:
  *   - `PushedAuthorizationRequestSigned` when JAR signing is required (contains `request` JWT)
- *   - `PushedAuthorizationRequestUnsigned` when JAR signing is not required (contains `authorizationRequest` object)
+ *   - version-specific unsigned PAR when JAR signing is not required (contains `authorizationRequest` object)
  *
  * @throws {PushedAuthorizationRequestError} If DPoP signer is missing required properties (alg, publicJwk.kid)
  * @throws {PushedAuthorizationRequestError} If PKCE code challenge method is not supported

--- a/packages/oauth2/src/authorization-request/create-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/create-authorization-request.ts
@@ -8,6 +8,7 @@ import {
   addSecondsToDate,
   dateToSeconds,
   encodeToBase64Url,
+  hasConfigVersion,
 } from "@pagopa/io-wallet-utils";
 
 import { PushedAuthorizationRequestError } from "../errors";
@@ -117,10 +118,8 @@ export interface CreatePushedAuthorizationRequestOptionsV1_0
   responseMode: string;
 }
 
-export interface CreatePushedAuthorizationRequestOptionsV1_3
-  extends BaseCreatePushedAuthorizationRequestOptions<ItWalletSpecsVersion.V1_3> {
-  responseMode?: never;
-}
+export type CreatePushedAuthorizationRequestOptionsV1_3 =
+  BaseCreatePushedAuthorizationRequestOptions<ItWalletSpecsVersion.V1_3>;
 
 export type CreatePushedAuthorizationRequestOptions =
   | CreatePushedAuthorizationRequestOptionsV1_0
@@ -366,14 +365,14 @@ function parseAuthorizationRequestByVersion(
 ): AuthorizationRequest {
   const version = options.config.itWalletSpecsVersion;
 
-  if (version === ItWalletSpecsVersion.V1_0) {
+  if (hasConfigVersion(options, ItWalletSpecsVersion.V1_0)) {
     return zAuthorizationRequestV1_0.parse({
       ...baseAuthorizationRequest,
       response_mode: options.responseMode,
     }) satisfies AuthorizationRequestV1_0;
   }
 
-  if (version === ItWalletSpecsVersion.V1_3) {
+  if (hasConfigVersion(options, ItWalletSpecsVersion.V1_3)) {
     return zAuthorizationRequestV1_3.parse(
       baseAuthorizationRequest,
     ) satisfies AuthorizationRequestV1_3;

--- a/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
@@ -21,10 +21,13 @@ import {
   parseAuthorizationRequest,
 } from "./parse-authorization-request";
 import {
-  AuthorizationRequest,
+  AuthorizationRequestV1_0,
+  AuthorizationRequestV1_3,
   zAuthorizationRequestV1_0,
   zAuthorizationRequestV1_3,
 } from "./z-authorization-request";
+
+type AuthorizationRequest = AuthorizationRequestV1_0 | AuthorizationRequestV1_3;
 
 export interface ParsePushedAuthorizationRequestOptions {
   authorizationRequest: unknown;

--- a/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
@@ -1,5 +1,8 @@
 import { CallbackContext } from "@openid4vc/oauth2";
 import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+  ItWalletSpecsVersionError,
   RequestLike,
   formatZodError,
   parseWithErrorHandling,
@@ -20,11 +23,14 @@ import {
 import {
   AuthorizationRequest,
   zAuthorizationRequest,
+  zAuthorizationRequestV1_0,
+  zAuthorizationRequestV1_3,
 } from "./z-authorization-request";
 
 export interface ParsePushedAuthorizationRequestOptions {
   authorizationRequest: unknown;
   callbacks: Pick<CallbackContext, "fetch">;
+  config: IoWalletSdkConfig;
   request: RequestLike;
 }
 
@@ -57,8 +63,12 @@ export interface ParsePushedAuthorizationRequestResult
 export async function parsePushedAuthorizationRequest(
   options: ParsePushedAuthorizationRequestOptions,
 ): Promise<ParsePushedAuthorizationRequestResult> {
+  const authorizationRequestSchema = getAuthorizationRequestSchema(
+    options.config,
+  );
+
   const parsed = parseWithErrorHandling(
-    z.union([zAuthorizationRequest, zJarAuthorizationRequest]),
+    z.union([authorizationRequestSchema, zJarAuthorizationRequest]),
     options.authorizationRequest,
     "Invalid authorization request. Could not parse authorization request or jar.",
   );
@@ -79,7 +89,9 @@ export async function parsePushedAuthorizationRequest(
       jwt: parsedJar.authorizationRequestJwt,
     });
 
-    parsedAuthorizationRequest = zAuthorizationRequest.safeParse(jwt.payload);
+    parsedAuthorizationRequest = authorizationRequestSchema.safeParse(
+      jwt.payload,
+    );
     if (!parsedAuthorizationRequest.success) {
       throw new Oauth2Error(
         `Invalid authorization request. Could not parse jar request payload.\n${formatZodError(parsedAuthorizationRequest.error)}`,
@@ -88,7 +100,7 @@ export async function parsePushedAuthorizationRequest(
 
     authorizationRequestJwt = parsedJar.authorizationRequestJwt;
   } else {
-    parsedAuthorizationRequest = zAuthorizationRequest.safeParse(
+    parsedAuthorizationRequest = authorizationRequestSchema.safeParse(
       options.authorizationRequest,
     );
     if (!parsedAuthorizationRequest.success) {
@@ -109,4 +121,20 @@ export async function parsePushedAuthorizationRequest(
     clientAttestation,
     dpop,
   };
+}
+
+function getAuthorizationRequestSchema(config: IoWalletSdkConfig) {
+  if (config.isVersion(ItWalletSpecsVersion.V1_0)) {
+    return zAuthorizationRequestV1_0;
+  }
+
+  if (config.isVersion(ItWalletSpecsVersion.V1_3)) {
+    return zAuthorizationRequestV1_3;
+  }
+
+  throw new ItWalletSpecsVersionError(
+    "parsePushedAuthorizationRequest",
+    config.itWalletSpecsVersion,
+    [ItWalletSpecsVersion.V1_0, ItWalletSpecsVersion.V1_3],
+  );
 }

--- a/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/parse-pushed-authorization-request.ts
@@ -22,7 +22,6 @@ import {
 } from "./parse-authorization-request";
 import {
   AuthorizationRequest,
-  zAuthorizationRequest,
   zAuthorizationRequestV1_0,
   zAuthorizationRequestV1_3,
 } from "./z-authorization-request";
@@ -73,9 +72,7 @@ export async function parsePushedAuthorizationRequest(
     "Invalid authorization request. Could not parse authorization request or jar.",
   );
 
-  let parsedAuthorizationRequest: ReturnType<
-    typeof zAuthorizationRequest.safeParse
-  >;
+  let parsedAuthorizationRequest: z.ZodSafeParseResult<AuthorizationRequest>;
 
   let authorizationRequestJwt: string | undefined;
   if (isJarAuthorizationRequest(parsed)) {

--- a/packages/oauth2/src/authorization-request/z-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/z-authorization-request.ts
@@ -14,26 +14,38 @@ const zItL2DocumentProofAuthorizationDetails = z.object({
   type: z.literal("it_l2+document_proof"),
 });
 
-export const zAuthorizationRequest = z
-  .looseObject({
-    authorization_details: z
-      .array(
-        z.discriminatedUnion("type", [
-          zOpenidCredentialAuthorizationDetails,
-          zItL2DocumentProofAuthorizationDetails,
-        ]),
-      )
-      .optional(),
-    client_id: z.string(),
-    code_challenge: z.string(),
-    code_challenge_method: z.string(),
-    issuer_state: z.optional(z.string()),
-    jti: z.string().max(MAX_JTI_LENGTH),
-    redirect_uri: z.url(),
+const zAuthorizationRequestBaseObject = z.looseObject({
+  authorization_details: z
+    .array(
+      z.discriminatedUnion("type", [
+        zOpenidCredentialAuthorizationDetails,
+        zItL2DocumentProofAuthorizationDetails,
+      ]),
+    )
+    .optional(),
+  client_id: z.string(),
+  code_challenge: z.string(),
+  code_challenge_method: z.string(),
+  issuer_state: z.optional(z.string()),
+  jti: z.string().max(MAX_JTI_LENGTH),
+  redirect_uri: z.url(),
+  response_type: z.string(),
+  scope: z.string().optional(),
+  state: z.string(),
+});
+
+const zAuthorizationRequestBase = zAuthorizationRequestBaseObject.refine(
+  (data) =>
+    data.authorization_details !== undefined || data.scope !== undefined,
+  {
+    message: "Either 'authorization_details' or 'scope' must be provided.",
+    path: ["authorization_details"],
+  },
+);
+
+export const zAuthorizationRequestV1_0 = zAuthorizationRequestBaseObject
+  .extend({
     response_mode: z.string(),
-    response_type: z.string(),
-    scope: z.string().optional(),
-    state: z.string(),
   })
   .refine(
     (data) =>
@@ -43,6 +55,20 @@ export const zAuthorizationRequest = z
       path: ["authorization_details"],
     },
   );
+
+export type AuthorizationRequestV1_0 = z.infer<
+  typeof zAuthorizationRequestV1_0
+>;
+
+export const zAuthorizationRequestV1_3 = zAuthorizationRequestBase;
+export type AuthorizationRequestV1_3 = z.infer<
+  typeof zAuthorizationRequestV1_3
+>;
+
+export const zAuthorizationRequest = z.union([
+  zAuthorizationRequestV1_0,
+  zAuthorizationRequestV1_3,
+]);
 export type AuthorizationRequest = z.infer<typeof zAuthorizationRequest>;
 
 export const zPushedAuthorizationRequestSigned = z.looseObject({
@@ -67,23 +93,45 @@ export type PushedAuthorizationRequestSigned = z.infer<
   typeof zPushedAuthorizationRequestSigned
 >;
 
-export const zPushedAuthorizationRequestUnsigned = z.looseObject({
-  authorizationRequest: zAuthorizationRequest.describe(
-    "The authorization request parameters as a plain object. " +
-      "Used when require_signed_request_object is false.",
-  ),
-  client_id: z
-    .string()
-    .describe(
-      "Thumbprint of the jwk value in the cnf parameter inside Wallet Attestation.",
+const zPushedAuthorizationRequestUnsignedBase = <
+  TAuthorizationRequest extends z.ZodType,
+>(
+  authorizationRequest: TAuthorizationRequest,
+) =>
+  z.looseObject({
+    authorizationRequest: authorizationRequest.describe(
+      "The authorization request parameters as a plain object. " +
+        "Used when require_signed_request_object is false.",
     ),
-  pkceCodeVerifier: z
-    .string()
-    .describe("PKCE code verifier. Auto-generated if not provided in options."),
-});
-export type PushedAuthorizationRequestUnsigned = z.infer<
-  typeof zPushedAuthorizationRequestUnsigned
+    client_id: z
+      .string()
+      .describe(
+        "Thumbprint of the jwk value in the cnf parameter inside Wallet Attestation.",
+      ),
+    pkceCodeVerifier: z
+      .string()
+      .describe(
+        "PKCE code verifier. Auto-generated if not provided in options.",
+      ),
+  });
+
+export const zPushedAuthorizationRequestUnsignedV1_0 =
+  zPushedAuthorizationRequestUnsignedBase(zAuthorizationRequestV1_0);
+export type PushedAuthorizationRequestUnsignedV1_0 = z.infer<
+  typeof zPushedAuthorizationRequestUnsignedV1_0
 >;
+
+export const zPushedAuthorizationRequestUnsignedV1_3 =
+  zPushedAuthorizationRequestUnsignedBase(zAuthorizationRequestV1_3);
+export type PushedAuthorizationRequestUnsignedV1_3 = z.infer<
+  typeof zPushedAuthorizationRequestUnsignedV1_3
+>;
+
+export const zPushedAuthorizationRequestUnsigned =
+  zPushedAuthorizationRequestUnsignedBase(zAuthorizationRequest);
+export type PushedAuthorizationRequestUnsigned =
+  | PushedAuthorizationRequestUnsignedV1_0
+  | PushedAuthorizationRequestUnsignedV1_3;
 
 /**
  * Union type for Pushed Authorization Request - can be either signed (JAR) or unsigned.

--- a/packages/oauth2/src/authorization-request/z-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/z-authorization-request.ts
@@ -65,12 +65,6 @@ export type AuthorizationRequestV1_3 = z.infer<
   typeof zAuthorizationRequestV1_3
 >;
 
-export const zAuthorizationRequest = z.union([
-  zAuthorizationRequestV1_0,
-  zAuthorizationRequestV1_3,
-]);
-export type AuthorizationRequest = z.infer<typeof zAuthorizationRequest>;
-
 export const zPushedAuthorizationRequestSigned = z.looseObject({
   client_id: z
     .string()
@@ -127,19 +121,14 @@ export type PushedAuthorizationRequestUnsignedV1_3 = z.infer<
   typeof zPushedAuthorizationRequestUnsignedV1_3
 >;
 
-export const zPushedAuthorizationRequestUnsigned =
-  zPushedAuthorizationRequestUnsignedBase(zAuthorizationRequest);
-export type PushedAuthorizationRequestUnsigned =
-  | PushedAuthorizationRequestUnsignedV1_0
-  | PushedAuthorizationRequestUnsignedV1_3;
-
 /**
  * Union type for Pushed Authorization Request - can be either signed (JAR) or unsigned.
  * The variant depends on the Authorization Server's require_signed_request_object metadata.
  */
 export type PushedAuthorizationRequest =
   | PushedAuthorizationRequestSigned
-  | PushedAuthorizationRequestUnsigned;
+  | PushedAuthorizationRequestUnsignedV1_0
+  | PushedAuthorizationRequestUnsignedV1_3;
 
 export function isPushedAuthorizationRequestSigned(
   par: PushedAuthorizationRequest,
@@ -149,7 +138,9 @@ export function isPushedAuthorizationRequestSigned(
 
 export function isPushedAuthorizationRequestUnsigned(
   par: PushedAuthorizationRequest,
-): par is PushedAuthorizationRequestUnsigned {
+): par is
+  | PushedAuthorizationRequestUnsignedV1_0
+  | PushedAuthorizationRequestUnsignedV1_3 {
   return "authorizationRequest" in par;
 }
 


### PR DESCRIPTION
This pull request introduces comprehensive updates to the OAuth2 authorization request test suite and core logic, primarily to support and validate differences between v1.0 and v1.3 of the ItWallet specification. The changes ensure correct handling of the `response_mode` parameter: it is required for v1.0 requests but must be omitted for v1.3 requests. The updates include stricter type checks, new and updated tests, and adjustments to core request-building logic.

Resolves WLEO-1156

Key changes include:

**Support for v1.3 specification and response_mode handling:**

* Updated tests and core logic to ensure that `response_mode` is not included in v1.3 authorization requests, with new tests verifying its absence and type-level checks to reject its usage in v1.3 options. [[1]](diffhunk://#diff-d6142b6b0eab3ce21ff2df1632964021a9fff1d6a5efffc1f3ca67b54a99cdacR1-R4) [[2]](diffhunk://#diff-d6142b6b0eab3ce21ff2df1632964021a9fff1d6a5efffc1f3ca67b54a99cdacR235-R267) [[3]](diffhunk://#diff-d6142b6b0eab3ce21ff2df1632964021a9fff1d6a5efffc1f3ca67b54a99cdacR417-R439) [[4]](diffhunk://#diff-8493c359c9aea37967f2f642146bed82f1e298718782c3daf3710bc68851e322R369-R422) [[5]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR77-R131) [[6]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR191-R208)
* Added configuration objects (`IoWalletSdkConfig`) for both v1.0 and v1.3 in test setups, and passed them explicitly to relevant functions to drive version-specific behavior. [[1]](diffhunk://#diff-d6142b6b0eab3ce21ff2df1632964021a9fff1d6a5efffc1f3ca67b54a99cdacR42-R49) [[2]](diffhunk://#diff-d6142b6b0eab3ce21ff2df1632964021a9fff1d6a5efffc1f3ca67b54a99cdacR64) [[3]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR15-R20) [[4]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR53) [[5]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR141) [[6]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR162) [[7]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR182) [[8]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR227) [[9]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR254) [[10]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR272) [[11]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR303) [[12]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR324) [[13]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR344) [[14]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR361) [[15]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR397) [[16]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR420)

**Type safety and stricter validation:**

* Refactored `CreatePushedAuthorizationRequestOptions` to be versioned and generic, enforcing at compile time that `responseMode` is not allowed for v1.3 requests. [[1]](diffhunk://#diff-095deb79e1a2e821a363a87824a9460e6e344ad4325c338bcda48d4bb61775e8R17-R32) [[2]](diffhunk://#diff-095deb79e1a2e821a363a87824a9460e6e344ad4325c338bcda48d4bb61775e8R67-R68)
* Improved validation in `parsePushedAuthorizationRequest` to throw errors for missing `response_mode` in v1.0, and to accept its absence in v1.3, with corresponding test coverage.

**Test coverage improvements:**

* Added/updated tests to ensure correct parsing and handling of unsigned and signed requests for both v1.0 and v1.3, including tests for error cases and edge conditions. [[1]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR77-R131) [[2]](diffhunk://#diff-916b8e327251f16ea41959c021984e6cf6f002917c5028c3792c9e90527cd79aR191-R208) [[3]](diffhunk://#diff-8493c359c9aea37967f2f642146bed82f1e298718782c3daf3710bc68851e322R369-R422)

**Internal code structure and imports:**

* Updated imports and internal type usage to support versioned request types and schemas, improving maintainability and clarity. [[1]](diffhunk://#diff-095deb79e1a2e821a363a87824a9460e6e344ad4325c338bcda48d4bb61775e8R5-R7) [[2]](diffhunk://#diff-095deb79e1a2e821a363a87824a9460e6e344ad4325c338bcda48d4bb61775e8R17-R32)

These changes ensure the codebase is robust against version-specific requirements and regressions, and that future updates to the ItWallet specification can be incorporated with minimal risk.