### PR TITLE
fix(oauth2): align wallet attestation JWT generation to set the sub claim to the RFC 7638-compliant DPoP JWK thumbprint

### DIFF
--- a/.changeset/wallet-attestation-thumbprint-sub.md
+++ b/.changeset/wallet-attestation-thumbprint-sub.md
@@ -1,6 +1,6 @@
 ---
-"@pagopa/io-wallet-oauth2": patch
-"@pagopa/io-wallet-oid4vci": patch
+"@pagopa/io-wallet-oauth2": minor
+"@pagopa/io-wallet-oid4vci": minor
 ---
 
 Use the RFC 7638 DPoP JWK thumbprint as the Wallet Attestation JWT `sub` claim.

--- a/.changeset/wallet-attestation-thumbprint-sub.md
+++ b/.changeset/wallet-attestation-thumbprint-sub.md
@@ -1,0 +1,6 @@
+---
+"@pagopa/io-wallet-oauth2": patch
+"@pagopa/io-wallet-oid4vci": patch
+---
+
+Use the RFC 7638 DPoP JWK thumbprint as the Wallet Attestation JWT `sub` claim.

--- a/packages/oauth2/src/client-attestation/__tests__/jwk-thumbprint.test.ts
+++ b/packages/oauth2/src/client-attestation/__tests__/jwk-thumbprint.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ClientAttestationError } from "../../errors";
+import { calculateDpopJwkThumbprint } from "../jwk-thumbprint";
+
+describe("calculateDpopJwkThumbprint", () => {
+  it("throws a clear error when the JWK key type is not supported", () => {
+    const hash = vi.fn();
+
+    expect(() =>
+      calculateDpopJwkThumbprint({
+        callbacks: { hash },
+        dpopJwkPublic: {
+          crv: "Ed25519",
+          kty: "OKP",
+          x: "test-x-value",
+        },
+      }),
+    ).toThrow(ClientAttestationError);
+
+    expect(() =>
+      calculateDpopJwkThumbprint({
+        callbacks: { hash },
+        dpopJwkPublic: {
+          crv: "Ed25519",
+          kty: "OKP",
+          x: "test-x-value",
+        },
+      }),
+    ).toThrow(
+      'Unsupported JWK key type "OKP" for thumbprint computation. Supported types: RSA, EC.',
+    );
+  });
+});

--- a/packages/oauth2/src/client-attestation/jwk-thumbprint.ts
+++ b/packages/oauth2/src/client-attestation/jwk-thumbprint.ts
@@ -1,0 +1,12 @@
+import { HashAlgorithm, calculateJwkThumbprint } from "@openid4vc/oauth2";
+
+import { type BaseWalletAttestationOptions } from "./types";
+
+export const calculateDpopJwkThumbprint = (
+  options: Pick<BaseWalletAttestationOptions, "callbacks" | "dpopJwkPublic">,
+) =>
+  calculateJwkThumbprint({
+    hashAlgorithm: HashAlgorithm.Sha256,
+    hashCallback: options.callbacks.hash,
+    jwk: options.dpopJwkPublic,
+  });

--- a/packages/oauth2/src/client-attestation/jwk-thumbprint.ts
+++ b/packages/oauth2/src/client-attestation/jwk-thumbprint.ts
@@ -5,6 +5,9 @@ import {
 } from "@openid4vc/oauth2";
 
 import { Jwk } from "../common/jwk/z-jwk";
+import { ClientAttestationError } from "../errors";
+
+const SUPPORTED_KTY = ["RSA", "EC"] as const;
 
 interface JwkThumbprintOptions {
   callbacks: Pick<CallbackContext, "hash">;
@@ -13,9 +16,20 @@ interface JwkThumbprintOptions {
 
 export const calculateDpopJwkThumbprint = (
   options: JwkThumbprintOptions,
-): Promise<string> =>
-  calculateJwkThumbprint({
+): Promise<string> => {
+  if (
+    !SUPPORTED_KTY.includes(
+      options.dpopJwkPublic.kty as (typeof SUPPORTED_KTY)[number],
+    )
+  ) {
+    throw new ClientAttestationError(
+      `Unsupported JWK key type "${options.dpopJwkPublic.kty}" for thumbprint computation. Supported types: ${SUPPORTED_KTY.join(", ")}.`,
+    );
+  }
+
+  return calculateJwkThumbprint({
     hashAlgorithm: HashAlgorithm.Sha256,
     hashCallback: options.callbacks.hash,
     jwk: options.dpopJwkPublic,
   });
+};

--- a/packages/oauth2/src/client-attestation/jwk-thumbprint.ts
+++ b/packages/oauth2/src/client-attestation/jwk-thumbprint.ts
@@ -1,10 +1,19 @@
-import { HashAlgorithm, calculateJwkThumbprint } from "@openid4vc/oauth2";
+import {
+  CallbackContext,
+  HashAlgorithm,
+  calculateJwkThumbprint,
+} from "@openid4vc/oauth2";
 
-import { type BaseWalletAttestationOptions } from "./types";
+import { Jwk } from "../common/jwk/z-jwk";
+
+interface JwkThumbprintOptions {
+  callbacks: Pick<CallbackContext, "hash">;
+  dpopJwkPublic: Jwk;
+}
 
 export const calculateDpopJwkThumbprint = (
-  options: Pick<BaseWalletAttestationOptions, "callbacks" | "dpopJwkPublic">,
-) =>
+  options: JwkThumbprintOptions,
+): Promise<string> =>
   calculateJwkThumbprint({
     hashAlgorithm: HashAlgorithm.Sha256,
     hashCallback: options.callbacks.hash,

--- a/packages/oauth2/src/client-attestation/types.ts
+++ b/packages/oauth2/src/client-attestation/types.ts
@@ -14,7 +14,7 @@ export interface BaseVerifyWalletAttestationJwtOptions {
  * Base options shared across all wallet attestation versions
  */
 export interface BaseWalletAttestationOptions {
-  callbacks: Pick<CallbackContext, "signJwt">;
+  callbacks: Pick<CallbackContext, "hash" | "signJwt">;
   dpopJwkPublic: ClientAttestationJwtPayload["cnf"]["jwk"];
   expiresAt?: Date;
   issuer: string;

--- a/packages/oauth2/src/client-attestation/v1.0/__tests__/create-wallet-attestation-jwt.test.ts
+++ b/packages/oauth2/src/client-attestation/v1.0/__tests__/create-wallet-attestation-jwt.test.ts
@@ -9,7 +9,9 @@ import { ClientAttestationError } from "../../../errors";
 import { createWalletAttestationJwt } from "../create-wallet-attestation-jwt";
 
 describe("createWalletAttestationJwt v1.0", () => {
+  const mockHash = vi.fn();
   const mockSignJwt = vi.fn();
+  const mockJwkThumbprint = "AQID";
   const mockConfig = new IoWalletSdkConfig({
     itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
   }) as { itWalletSpecsVersion: ItWalletSpecsVersion.V1_0 } & IoWalletSdkConfig;
@@ -30,6 +32,7 @@ describe("createWalletAttestationJwt v1.0", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHash.mockResolvedValue(new Uint8Array([1, 2, 3]));
     mockSignJwt.mockResolvedValue({ jwt: mockJwt });
   });
 
@@ -37,7 +40,7 @@ describe("createWalletAttestationJwt v1.0", () => {
     it("should create a valid wallet attestation JWT with required fields", async () => {
       const options = {
         authenticatorAssuranceLevel: "aal1",
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
@@ -69,7 +72,7 @@ describe("createWalletAttestationJwt v1.0", () => {
             exp: dateToSeconds(new Date("2025-01-25T00:00:00Z")),
             iat: expect.any(Number),
             iss: "https://wallet-provider.example.com",
-            sub: "test-key-id",
+            sub: mockJwkThumbprint,
           }),
         }),
       );
@@ -78,7 +81,7 @@ describe("createWalletAttestationJwt v1.0", () => {
     it("should include both walletLink and walletName when provided", async () => {
       const options = {
         authenticatorAssuranceLevel: "aal1",
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
@@ -111,7 +114,7 @@ describe("createWalletAttestationJwt v1.0", () => {
     it("should set typ header to oauth-client-attestation+jwt", async () => {
       const options = {
         authenticatorAssuranceLevel: "aal1",
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
@@ -140,7 +143,7 @@ describe("createWalletAttestationJwt v1.0", () => {
 
       const options = {
         authenticatorAssuranceLevel: "aal1",
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),

--- a/packages/oauth2/src/client-attestation/v1.0/__tests__/create-wallet-attestation-jwt.test.ts
+++ b/packages/oauth2/src/client-attestation/v1.0/__tests__/create-wallet-attestation-jwt.test.ts
@@ -1,20 +1,16 @@
-import {
-  IoWalletSdkConfig,
-  ItWalletSpecsVersion,
-  dateToSeconds,
-} from "@pagopa/io-wallet-utils";
+import { dateToSeconds } from "@pagopa/io-wallet-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ClientAttestationError } from "../../../errors";
-import { createWalletAttestationJwt } from "../create-wallet-attestation-jwt";
+import {
+  WalletAttestationOptionsV1_0,
+  createWalletAttestationJwt,
+} from "../create-wallet-attestation-jwt";
 
 describe("createWalletAttestationJwt v1.0", () => {
   const mockHash = vi.fn();
   const mockSignJwt = vi.fn();
   const mockJwkThumbprint = "AQID";
-  const mockConfig = new IoWalletSdkConfig({
-    itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
-  }) as { itWalletSpecsVersion: ItWalletSpecsVersion.V1_0 } & IoWalletSdkConfig;
 
   const mockJwk = {
     crv: "P-256",
@@ -38,10 +34,9 @@ describe("createWalletAttestationJwt v1.0", () => {
 
   describe("successful JWT creation", () => {
     it("should create a valid wallet attestation JWT with required fields", async () => {
-      const options = {
+      const options: WalletAttestationOptionsV1_0 = {
         authenticatorAssuranceLevel: "aal1",
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",
@@ -79,10 +74,9 @@ describe("createWalletAttestationJwt v1.0", () => {
     });
 
     it("should include both walletLink and walletName when provided", async () => {
-      const options = {
+      const options: WalletAttestationOptionsV1_0 = {
         authenticatorAssuranceLevel: "aal1",
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",
@@ -112,10 +106,9 @@ describe("createWalletAttestationJwt v1.0", () => {
 
   describe("v1.0 specific constraints", () => {
     it("should set typ header to oauth-client-attestation+jwt", async () => {
-      const options = {
+      const options: WalletAttestationOptionsV1_0 = {
         authenticatorAssuranceLevel: "aal1",
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",
@@ -141,10 +134,9 @@ describe("createWalletAttestationJwt v1.0", () => {
     it("should wrap unexpected errors in ClientAttestationError", async () => {
       mockSignJwt.mockRejectedValue(new Error("Unexpected signing error"));
 
-      const options = {
+      const options: WalletAttestationOptionsV1_0 = {
         authenticatorAssuranceLevel: "aal1",
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",

--- a/packages/oauth2/src/client-attestation/v1.0/create-wallet-attestation-jwt.ts
+++ b/packages/oauth2/src/client-attestation/v1.0/create-wallet-attestation-jwt.ts
@@ -6,6 +6,7 @@ import {
 
 import { decodeJwt } from "../../common/jwt/decode-jwt";
 import { ClientAttestationError } from "../../errors";
+import { calculateDpopJwkThumbprint } from "../jwk-thumbprint";
 import { BaseWalletAttestationOptions } from "../types";
 import {
   WalletAttestationJwtV1_0,
@@ -51,13 +52,14 @@ export const createWalletAttestationJwt = async (
     const { signJwt } = options.callbacks;
     const iat = new Date();
     const exp = options.expiresAt ?? addSecondsToDate(iat, 3600); // Default expiration of 1 hour
+    const dpopJwkThumbprint = await calculateDpopJwkThumbprint(options);
 
     const payload = {
       cnf: { jwk: options.dpopJwkPublic },
       exp: dateToSeconds(exp),
       iat: dateToSeconds(iat),
       iss: options.issuer,
-      sub: options.dpopJwkPublic.kid,
+      sub: dpopJwkThumbprint,
       ...(options.walletLink && { wallet_link: options.walletLink }),
       ...(options.walletName && { wallet_name: options.walletName }),
       aal: options.authenticatorAssuranceLevel,

--- a/packages/oauth2/src/client-attestation/v1.3/__tests__/create-wallet-attestation-jwt.test.ts
+++ b/packages/oauth2/src/client-attestation/v1.3/__tests__/create-wallet-attestation-jwt.test.ts
@@ -9,7 +9,9 @@ import { ClientAttestationError } from "../../../errors";
 import { createWalletAttestationJwt } from "../create-wallet-attestation-jwt";
 
 describe("createWalletAttestationJwt v1.3", () => {
+  const mockHash = vi.fn();
   const mockSignJwt = vi.fn();
+  const mockJwkThumbprint = "AQID";
   const mockConfig = new IoWalletSdkConfig({
     itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
   }) as { itWalletSpecsVersion: ItWalletSpecsVersion.V1_3 } & IoWalletSdkConfig;
@@ -29,6 +31,7 @@ describe("createWalletAttestationJwt v1.3", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHash.mockResolvedValue(new Uint8Array([1, 2, 3]));
     mockSignJwt.mockResolvedValue({
       jwt: "eyJhbGciOiJFUzI1NiIsInR5cCI6Im9hdXRoLWNsaWVudC1hdHRlc3RhdGlvbitqd3QiLCJraWQiOiJ0ZXN0LWtpZCIsIng1YyI6WyJNSUlDZXJ0aWZpY2F0ZTFCYXNlNjQ9PSIsIk1JSUNLZXJ0aWZpY2F0ZTJCYXNlNjQ9PSJdfQ.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLmNvbSIsInN1YiI6InRlc3QtY2xpZW50LWlkIiwiaWF0IjoxNzM4MjQzMjAwLCJleHAiOjE3NDMzMzk2MDAsImNuZiI6eyJqd2siOnsiY3J2IjoiUC0yNTYiLCJraWQiOiJ0ZXN0LWtleS1pZCIsImt0eSI6IkVDIiwieCI6InRlc3QteC12YWx1ZSIsInkiOiJ0ZXN0LXktdmFsdWUifX19.signature",
     });
@@ -37,7 +40,7 @@ describe("createWalletAttestationJwt v1.3", () => {
   describe("successful JWT creation", () => {
     it("should create a valid wallet attestation JWT with x5c", async () => {
       const options = {
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
@@ -69,7 +72,7 @@ describe("createWalletAttestationJwt v1.3", () => {
             exp: dateToSeconds(new Date("2025-01-25T00:00:00Z")),
             iat: expect.any(Number),
             iss: "https://wallet-provider.example.com",
-            sub: "test-key-id",
+            sub: mockJwkThumbprint,
           }),
         }),
       );
@@ -78,7 +81,7 @@ describe("createWalletAttestationJwt v1.3", () => {
     it("should include optional nbf when provided", async () => {
       const nbfDate = new Date("2025-01-01T00:00:00Z");
       const options = {
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
@@ -108,7 +111,7 @@ describe("createWalletAttestationJwt v1.3", () => {
   describe("nbf validation", () => {
     it("should accept when nbf is before exp", async () => {
       const options = {
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
@@ -131,7 +134,7 @@ describe("createWalletAttestationJwt v1.3", () => {
       mockSignJwt.mockRejectedValue(new Error("Crypto module crashed"));
 
       const options = {
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),

--- a/packages/oauth2/src/client-attestation/v1.3/__tests__/create-wallet-attestation-jwt.test.ts
+++ b/packages/oauth2/src/client-attestation/v1.3/__tests__/create-wallet-attestation-jwt.test.ts
@@ -1,20 +1,16 @@
-import {
-  IoWalletSdkConfig,
-  ItWalletSpecsVersion,
-  dateToSeconds,
-} from "@pagopa/io-wallet-utils";
+import { dateToSeconds } from "@pagopa/io-wallet-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ClientAttestationError } from "../../../errors";
-import { createWalletAttestationJwt } from "../create-wallet-attestation-jwt";
+import {
+  WalletAttestationOptionsV1_3,
+  createWalletAttestationJwt,
+} from "../create-wallet-attestation-jwt";
 
 describe("createWalletAttestationJwt v1.3", () => {
   const mockHash = vi.fn();
   const mockSignJwt = vi.fn();
   const mockJwkThumbprint = "AQID";
-  const mockConfig = new IoWalletSdkConfig({
-    itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
-  }) as { itWalletSpecsVersion: ItWalletSpecsVersion.V1_3 } & IoWalletSdkConfig;
 
   const mockJwk = {
     crv: "P-256",
@@ -39,9 +35,8 @@ describe("createWalletAttestationJwt v1.3", () => {
 
   describe("successful JWT creation", () => {
     it("should create a valid wallet attestation JWT with x5c", async () => {
-      const options = {
+      const options: WalletAttestationOptionsV1_3 = {
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",
@@ -80,9 +75,8 @@ describe("createWalletAttestationJwt v1.3", () => {
 
     it("should include optional nbf when provided", async () => {
       const nbfDate = new Date("2025-01-01T00:00:00Z");
-      const options = {
+      const options: WalletAttestationOptionsV1_3 = {
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",
@@ -110,9 +104,8 @@ describe("createWalletAttestationJwt v1.3", () => {
 
   describe("nbf validation", () => {
     it("should accept when nbf is before exp", async () => {
-      const options = {
+      const options: WalletAttestationOptionsV1_3 = {
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",
@@ -133,9 +126,8 @@ describe("createWalletAttestationJwt v1.3", () => {
     it("should wrap unexpected errors in ClientAttestationError", async () => {
       mockSignJwt.mockRejectedValue(new Error("Crypto module crashed"));
 
-      const options = {
+      const options: WalletAttestationOptionsV1_3 = {
         callbacks: { hash: mockHash, signJwt: mockSignJwt },
-        config: mockConfig,
         dpopJwkPublic: mockJwk,
         expiresAt: new Date("2025-01-25T00:00:00Z"),
         issuer: "https://wallet-provider.example.com",

--- a/packages/oauth2/src/client-attestation/v1.3/create-wallet-attestation-jwt.ts
+++ b/packages/oauth2/src/client-attestation/v1.3/create-wallet-attestation-jwt.ts
@@ -6,6 +6,7 @@ import {
 
 import { decodeJwt } from "../../common/jwt/decode-jwt";
 import { ClientAttestationError } from "../../errors";
+import { calculateDpopJwkThumbprint } from "../jwk-thumbprint";
 import { BaseWalletAttestationOptions } from "../types";
 import {
   WalletAttestationJwtV1_3,
@@ -58,6 +59,7 @@ export const createWalletAttestationJwt = async (
     const { signJwt } = options.callbacks;
     const iat = new Date();
     const exp = options.expiresAt ?? addSecondsToDate(iat, 3600); // Default expiration of 1 hour
+    const dpopJwkThumbprint = await calculateDpopJwkThumbprint(options);
 
     // Validate temporal constraints
     if (options.nbf && options.nbf >= exp) {
@@ -69,7 +71,7 @@ export const createWalletAttestationJwt = async (
       exp: dateToSeconds(exp),
       iat: dateToSeconds(iat),
       iss: options.issuer,
-      sub: options.dpopJwkPublic.kid,
+      sub: dpopJwkThumbprint,
       ...(options.nbf && { nbf: dateToSeconds(options.nbf) }),
       ...(options.status && { status: options.status }),
       ...(options.walletLink && { wallet_link: options.walletLink }),

--- a/packages/oauth2/src/client-attestation/v1.3/create-wallet-attestation-jwt.ts
+++ b/packages/oauth2/src/client-attestation/v1.3/create-wallet-attestation-jwt.ts
@@ -59,12 +59,13 @@ export const createWalletAttestationJwt = async (
     const { signJwt } = options.callbacks;
     const iat = new Date();
     const exp = options.expiresAt ?? addSecondsToDate(iat, 3600); // Default expiration of 1 hour
-    const dpopJwkThumbprint = await calculateDpopJwkThumbprint(options);
 
     // Validate temporal constraints
     if (options.nbf && options.nbf >= exp) {
       throw new ValidationError("nbf must be before exp");
     }
+
+    const dpopJwkThumbprint = await calculateDpopJwkThumbprint(options);
 
     const payload = {
       cnf: { jwk: options.dpopJwkPublic },

--- a/packages/oauth2/src/client-attestation/v1.4/__tests__/create-wallet-attestation-jwt.test.ts
+++ b/packages/oauth2/src/client-attestation/v1.4/__tests__/create-wallet-attestation-jwt.test.ts
@@ -11,8 +11,17 @@ import {
   createWalletAttestationJwt,
 } from "../create-wallet-attestation-jwt";
 
+const buildJwt = (header: object, payload: object) =>
+  [
+    encodeToBase64Url(JSON.stringify(header)),
+    encodeToBase64Url(JSON.stringify(payload)),
+    "signature",
+  ].join(".");
+
 describe("createWalletAttestationJwt v1.4", () => {
+  const mockHash = vi.fn();
   const mockSignJwt = vi.fn();
+  const mockJwkThumbprint = "AQID";
 
   const mockJwk = {
     crv: "P-256",
@@ -28,7 +37,7 @@ describe("createWalletAttestationJwt v1.4", () => {
   ];
 
   const baseOptions: WalletAttestationOptionsV1_4 = {
-    callbacks: { signJwt: mockSignJwt },
+    callbacks: { hash: mockHash, signJwt: mockSignJwt },
     dpopJwkPublic: mockJwk,
     expiresAt: new Date("2025-01-25T00:00:00Z"),
     issuer: "https://wallet-provider.example.com",
@@ -48,25 +57,17 @@ describe("createWalletAttestationJwt v1.4", () => {
     walletName: "Test Wallet",
   };
 
-  const buildJwt = (header: object, payload: object) =>
-    [
-      encodeToBase64Url(JSON.stringify(header)),
-      encodeToBase64Url(JSON.stringify(payload)),
-      "signature",
-    ].join(".");
-
   beforeEach(() => {
     vi.clearAllMocks();
+    mockHash.mockResolvedValue(new Uint8Array([1, 2, 3]));
     mockSignJwt.mockImplementation(async (_signer, { header, payload }) => ({
       jwt: buildJwt(header, payload),
     }));
   });
 
   it("should create a valid wallet attestation JWT with required v1.4 claims", async () => {
-    const result = await createWalletAttestationJwt(baseOptions);
+    await createWalletAttestationJwt(baseOptions);
 
-    expect(result).toBeDefined();
-    expect(typeof result).toBe("string");
     expect(mockSignJwt).toHaveBeenCalledWith(
       baseOptions.signer,
       expect.objectContaining({
@@ -87,7 +88,7 @@ describe("createWalletAttestationJwt v1.4", () => {
               uri: "https://status.example.com/list",
             },
           },
-          sub: "test-key-id",
+          sub: mockJwkThumbprint,
           wallet_link: "https://wallet.example.com",
           wallet_name: "Test Wallet",
         }),
@@ -103,6 +104,30 @@ describe("createWalletAttestationJwt v1.4", () => {
       expect.objectContaining({
         payload: expect.not.objectContaining({
           eudi_wallet_info: expect.anything(),
+        }),
+      }),
+    );
+  });
+
+  it("should create a valid wallet attestation JWT when the DPoP JWK has no kid", async () => {
+    const options = {
+      ...baseOptions,
+      dpopJwkPublic: {
+        crv: "P-256",
+        kty: "EC",
+        x: "test-x-value",
+        y: "test-y-value",
+      },
+    };
+
+    await createWalletAttestationJwt(options);
+
+    expect(mockSignJwt).toHaveBeenCalledWith(
+      baseOptions.signer,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          cnf: { jwk: options.dpopJwkPublic },
+          sub: mockJwkThumbprint,
         }),
       }),
     );

--- a/packages/oauth2/src/client-attestation/v1.4/create-wallet-attestation-jwt.ts
+++ b/packages/oauth2/src/client-attestation/v1.4/create-wallet-attestation-jwt.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { decodeJwt } from "../../common/jwt/decode-jwt";
 import { ClientAttestationError } from "../../errors";
+import { calculateDpopJwkThumbprint } from "../jwk-thumbprint";
 import { BaseWalletAttestationOptions } from "../types";
 import {
   WalletAttestationJwtV1_4,
@@ -39,6 +40,7 @@ export const createWalletAttestationJwt = async (
     const { signJwt } = options.callbacks;
     const iat = new Date();
     const exp = options.expiresAt ?? addSecondsToDate(iat, 3600); // Default expiration of 1 hour
+    const dpopJwkThumbprint = await calculateDpopJwkThumbprint(options);
 
     // Validate temporal constraints
     if (options.nbf && options.nbf >= exp) {
@@ -51,7 +53,7 @@ export const createWalletAttestationJwt = async (
       iat: dateToSeconds(iat),
       iss: options.issuer,
       status: options.status,
-      sub: options.dpopJwkPublic.kid,
+      sub: dpopJwkThumbprint,
       wallet_link: options.walletLink,
       wallet_name: options.walletName,
       ...(options.nbf && { nbf: dateToSeconds(options.nbf) }),

--- a/packages/oauth2/src/client-attestation/v1.4/create-wallet-attestation-jwt.ts
+++ b/packages/oauth2/src/client-attestation/v1.4/create-wallet-attestation-jwt.ts
@@ -40,12 +40,13 @@ export const createWalletAttestationJwt = async (
     const { signJwt } = options.callbacks;
     const iat = new Date();
     const exp = options.expiresAt ?? addSecondsToDate(iat, 3600); // Default expiration of 1 hour
-    const dpopJwkThumbprint = await calculateDpopJwkThumbprint(options);
 
     // Validate temporal constraints
     if (options.nbf && options.nbf >= exp) {
       throw new ValidationError("nbf must be before exp");
     }
+
+    const dpopJwkThumbprint = await calculateDpopJwkThumbprint(options);
 
     const payload = {
       cnf: { jwk: options.dpopJwkPublic },

--- a/packages/oid4vci/README.md
+++ b/packages/oid4vci/README.md
@@ -307,7 +307,7 @@ export class Oid4vciError extends Error {
 ```
 Generic error thrown on Oid4vci operations
 
-Error thrown when wallet provider options do not match the configured IT-Wallet specification version
+Error thrown when wallet-provider options are invalid or when wallet attestation and key attestation JWT creation fails.
 ```typescript
 export class WalletProviderError extends Oid4vciError {
   constructor(message: string, cause?: unknown) {

--- a/packages/oid4vci/README.md
+++ b/packages/oid4vci/README.md
@@ -36,6 +36,7 @@ import { WalletProvider, WalletAttestationOptions } from '@pagopa/io-wallet-oid4
 
 // Create wallet attestation
 const attestationOptions: WalletAttestationOptions = {
+  callbacks: { hash: myHashCallback, signJwt: mySignJwtCallback },
   issuer: "https://wallet-provider.example.com",
   dpopJwkPublic: {
     // JWK public key for DPoP binding
@@ -306,7 +307,7 @@ export class Oid4vciError extends Error {
 ```
 Generic error thrown on Oid4vci operations
 
-Error thrown in case the DPoP key passed to the `WalletProvider.createItWalletAttestationJwt` method doesn't contain a kid
+Error thrown when wallet provider options do not match the configured IT-Wallet specification version
 ```typescript
 export class WalletProviderError extends Oid4vciError {
   constructor(message: string, cause?: unknown) {

--- a/packages/oid4vci/src/errors.ts
+++ b/packages/oid4vci/src/errors.ts
@@ -14,9 +14,8 @@ export class Oid4vciError extends Error {
 }
 
 /**
- * Error thrown in case the DPoP key passed to the
- * {@link WalletProvider.createItWalletAttestationJwt} method
- * receives options that do not match the configured IT-Wallet specification version
+ * Error thrown when wallet-provider options are invalid or when wallet
+ * attestation and key attestation creation fails.
  */
 export class WalletProviderError extends Oid4vciError {
   constructor(message: string, options?: ErrorOptions) {

--- a/packages/oid4vci/src/errors.ts
+++ b/packages/oid4vci/src/errors.ts
@@ -16,7 +16,7 @@ export class Oid4vciError extends Error {
 /**
  * Error thrown in case the DPoP key passed to the
  * {@link WalletProvider.createItWalletAttestationJwt} method
- * doesn't contain a kid
+ * receives options that do not match the configured IT-Wallet specification version
  */
 export class WalletProviderError extends Oid4vciError {
   constructor(message: string, options?: ErrorOptions) {

--- a/packages/oid4vci/src/wallet-provider/WalletProvider.ts
+++ b/packages/oid4vci/src/wallet-provider/WalletProvider.ts
@@ -205,18 +205,17 @@ export class WalletProvider {
    * - v1.0: Uses only `trust_chain` in header (federation method); no `status` claim
    * - v1.3: Requires `x5c` in header, optional `trust_chain`; supports optional `nbf` and `status` claims
    * - v1.4: Requires `x5c` in header, optional `trust_chain`; `status`, `wallet_link`, and `wallet_name`
-   *   are all **required**; optional `eudi_wallet_info` claim; sets `sub` to `dpopJwkPublic.kid`
+   *   are all **required**; optional `eudi_wallet_info` claim; sets `sub` to the DPoP JWK thumbprint
    *
    * @public
    * @async
    * @param {WalletAttestationOptions} options - The necessary parameters to build the attestation.
    * @returns {Promise<string>} A promise that resolves to the signed wallet attestation JWT as a string.
-   * @throws {WalletProviderError} When dpopJwkPublic.kid is missing
    * @throws {ItWalletSpecsVersionError} When version is not supported
    *
    * @example v1.0 - Basic wallet attestation with trust chain
    * const jwt = await provider.createItWalletAttestationJwt({
-   *   callbacks: { signJwt: mySignJwtCallback },
+   *   callbacks: { hash: myHashCallback, signJwt: mySignJwtCallback },
    *   dpopJwkPublic: myJwk,
    *   issuer: "https://wallet-provider.example.com",
    *   signer: {
@@ -228,7 +227,7 @@ export class WalletProvider {
    *
    * @example v1.3 - Wallet attestation with x5c and optional fields
    * const jwt = await provider.createItWalletAttestationJwt({
-   *   callbacks: { signJwt: mySignJwtCallback },
+   *   callbacks: { hash: myHashCallback, signJwt: mySignJwtCallback },
    *   dpopJwkPublic: myJwk,
    *   issuer: "https://wallet-provider.example.com",
    *   signer: {
@@ -243,7 +242,7 @@ export class WalletProvider {
    *
    * @example v1.4 - Wallet attestation with required status and optional eudi_wallet_info
    * const jwt = await provider.createItWalletAttestationJwt({
-   *   callbacks: { signJwt: mySignJwtCallback },
+   *   callbacks: { hash: myHashCallback, signJwt: mySignJwtCallback },
    *   dpopJwkPublic: myJwk,
    *   issuer: "https://wallet-provider.example.com",
    *   signer: {
@@ -270,12 +269,6 @@ export class WalletProvider {
   public async createItWalletAttestationJwt(
     options: WalletAttestationOptions,
   ): Promise<string> {
-    // Validate that dpopJwkPublic has a kid property
-    // This validation is common across all versions
-    if (!options.dpopJwkPublic.kid) {
-      throw new WalletProviderError("The DPoP JWK must have a 'kid' property");
-    }
-
     if (this.specVersion === ItWalletSpecsVersion.V1_0) {
       assertV1_0Options(options);
       return createWalletAttestationJwtV1_0({

--- a/packages/oid4vci/src/wallet-provider/WalletProvider.ts
+++ b/packages/oid4vci/src/wallet-provider/WalletProvider.ts
@@ -211,7 +211,12 @@ export class WalletProvider {
    * @async
    * @param {WalletAttestationOptions} options - The necessary parameters to build the attestation.
    * @returns {Promise<string>} A promise that resolves to the signed wallet attestation JWT as a string.
-   * @throws {ItWalletSpecsVersionError} When version is not supported
+   * @throws {WalletProviderError} When the provided options do not match the configured IT-Wallet
+   * specification version, or when v1.4 options are missing `walletLink`, `walletName`, or `status`.
+   * @throws {ValidationError} When the generated wallet attestation JWT fails validation.
+   * @throws {ClientAttestationError} When wallet attestation JWT creation fails unexpectedly,
+   * including signing errors from the configured `signJwt` callback.
+   * @throws {ItWalletSpecsVersionError} When the configured IT-Wallet specification version is not supported.
    *
    * @example v1.0 - Basic wallet attestation with trust chain
    * const jwt = await provider.createItWalletAttestationJwt({

--- a/packages/oid4vci/src/wallet-provider/__tests__/WalletProvider.v1.0.test.ts
+++ b/packages/oid4vci/src/wallet-provider/__tests__/WalletProvider.v1.0.test.ts
@@ -38,6 +38,7 @@ const mockCreateWalletAttestationJwtV1_3 =
   >;
 
 describe("WalletProvider v1.0", () => {
+  const mockHash = vi.fn();
   const mockSignJwt = vi.fn();
 
   const mockJwk = {
@@ -63,7 +64,7 @@ describe("WalletProvider v1.0", () => {
       const provider = new WalletProvider(invalidConfig);
 
       const options = {
-        callbacks: { signJwt: mockSignJwt },
+        callbacks: { hash: mockHash, signJwt: mockSignJwt },
         dpopJwkPublic: mockJwk,
         issuer: "https://wallet-provider.example.com",
         signer: {

--- a/packages/oid4vci/src/wallet-provider/__tests__/WalletProvider.v1.3.test.ts
+++ b/packages/oid4vci/src/wallet-provider/__tests__/WalletProvider.v1.3.test.ts
@@ -41,6 +41,7 @@ const mockCreateWalletAttestationJwtV1_3 =
   >;
 
 const mockSignJwt = vi.fn();
+const mockHash = vi.fn();
 
 const mockJwk = {
   crv: "P-256",
@@ -66,7 +67,7 @@ describe("WalletProvider v1.3 - version routing", () => {
 
     const options: WalletAttestationOptionsV1_0 = {
       authenticatorAssuranceLevel: "aal1",
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       issuer: "https://wallet-provider.example.com",
       signer: {
@@ -92,7 +93,7 @@ describe("WalletProvider v1.3 - version routing", () => {
     );
 
     const options: WalletAttestationOptionsV1_3 = {
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       issuer: "https://wallet-provider.example.com",
       signer: {
@@ -118,7 +119,7 @@ describe("WalletProvider v1.3 - version routing", () => {
     const provider = new WalletProvider(invalidConfig);
 
     const options = {
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       issuer: "https://wallet-provider.example.com",
       signer: {
@@ -145,7 +146,7 @@ describe("WalletProvider v1.3 - version mismatch", () => {
     );
 
     const v1_3Options: WalletAttestationOptionsV1_3 = {
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       issuer: "https://wallet-provider.example.com",
       signer: {
@@ -174,7 +175,7 @@ describe("WalletProvider v1.3 - version mismatch", () => {
 
     const v1_0Options: WalletAttestationOptionsV1_0 = {
       authenticatorAssuranceLevel: "aal1",
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       issuer: "https://wallet-provider.example.com",
       signer: {
@@ -212,7 +213,7 @@ describe("WalletProvider v1.3 - v1.3 routing", () => {
     };
 
     const options: WalletAttestationOptionsV1_3 = {
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       expiresAt: new Date("2025-06-01T00:00:00Z"),
       issuer: "https://wallet-provider.example.com",
@@ -232,7 +233,7 @@ describe("WalletProvider v1.3 - v1.3 routing", () => {
     await provider.createItWalletAttestationJwt(options);
 
     expect(mockCreateWalletAttestationJwtV1_3).toHaveBeenCalledWith({
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       expiresAt: new Date("2025-06-01T00:00:00Z"),
       issuer: "https://wallet-provider.example.com",

--- a/packages/oid4vci/src/wallet-provider/__tests__/WalletProvider.v1.4.test.ts
+++ b/packages/oid4vci/src/wallet-provider/__tests__/WalletProvider.v1.4.test.ts
@@ -45,6 +45,7 @@ const mockCreateWalletAttestationJwtV1_4 =
   >;
 
 describe("WalletProvider v1.4 routing", () => {
+  const mockHash = vi.fn();
   const mockSignJwt = vi.fn();
   const mockJwk = {
     crv: "P-256",
@@ -74,7 +75,7 @@ describe("WalletProvider v1.4 routing", () => {
 
   it("should route to v1.4 implementation when version is V1_4", async () => {
     const options: WalletAttestationOptionsV1_4 = {
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       issuer: "https://wallet-provider.example.com",
       signer: {
@@ -109,7 +110,7 @@ describe("WalletProvider v1.4 routing", () => {
       },
     };
     const options: WalletAttestationOptionsV1_4 = {
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       eudiWalletInfo,
       expiresAt: new Date("2025-06-01T00:00:00Z"),
@@ -127,7 +128,7 @@ describe("WalletProvider v1.4 routing", () => {
     await provider.createItWalletAttestationJwt(options);
 
     expect(mockCreateWalletAttestationJwtV1_4).toHaveBeenCalledWith({
-      callbacks: { signJwt: mockSignJwt },
+      callbacks: { hash: mockHash, signJwt: mockSignJwt },
       dpopJwkPublic: mockJwk,
       eudiWalletInfo,
       expiresAt: new Date("2025-06-01T00:00:00Z"),
@@ -147,7 +148,7 @@ describe("WalletProvider v1.4 routing", () => {
 
   describe("missing or invalid v1.4 options", () => {
     const baseOptions: WalletAttestationOptionsV1_4 = {
-      callbacks: { signJwt: vi.fn() },
+      callbacks: { hash: vi.fn(), signJwt: vi.fn() },
       dpopJwkPublic: {
         crv: "P-256",
         kid: "test-key-id",


### PR DESCRIPTION
This pull request updates the wallet attestation JWT implementation to use the RFC 7638 DPoP JWK thumbprint as the `sub` claim, improving interoperability and compliance with standards. It introduces a utility for thumbprint calculation, updates the relevant attestation creation logic, and adapts tests and documentation accordingly.

JIRA: WLEO-1158

**Wallet Attestation JWT Improvements:**

* The `sub` claim in wallet attestation JWTs is now set to the RFC 7638-compliant DPoP JWK thumbprint, replacing the previous use of the JWK's `kid` value. This ensures standards compliance and consistent subject identification. [[1]](diffhunk://#diff-843e19497819b507a8d1ffa2c594319e1e12495ac3a306c9ec36cf908c6f7810R55-R62) [[2]](diffhunk://#diff-ac962b53a63141d2b236313b2479ed2c2e8845f762c997e6a28ad3d184ae6ce7L72-R74) [[3]](diffhunk://#diff-44efc5328c96f1e3b8f92571fc18ac2438b1a70aab47aa6ddcb506286773739dL54-R56)
* Added a new utility function `calculateDpopJwkThumbprint` in `jwk-thumbprint.ts` to compute the JWK thumbprint using SHA-256, as required by RFC 7638.

**API and Types Updates:**

* The `BaseWalletAttestationOptions` interface now requires a `hash` callback in addition to `signJwt`, enabling the thumbprint calculation to be performed with a pluggable hash function.

**Test and Documentation Updates:**

* All attestation creation tests (v1.0, v1.3, v1.4) have been updated to expect and mock the new thumbprint-based `sub` claim, and to provide the required `hash` callback in test options. Tests now also cover the case where the JWK has no `kid`. [[1]](diffhunk://#diff-a5a72c9e1af6d6454c88cd366ac51d6baabfc5afe41af7f318725a56c71623b8L72-R75) [[2]](diffhunk://#diff-d85f904f196d438fedda5f4bfae8538dfda3f906e1e73d78429298357c24d6e1L72-R75) [[3]](diffhunk://#diff-179041c12f34fc7091b65112890dcea545eb95579415bc3b6af7b3acc82c594eL90-R91) [[4]](diffhunk://#diff-179041c12f34fc7091b65112890dcea545eb95579415bc3b6af7b3acc82c594eR112-R135)
* The `README.md` and changeset documentation have been updated to reflect the new requirement for the `hash` callback in attestation options and the behavioral change for the `sub` claim. [[1]](diffhunk://#diff-ba5112174f5d8e8360ac595ced116cc70554ae9f626a600b914d7f5fb0470c14R39) [[2]](diffhunk://#diff-7aea9896cbb3a2ffccee1069b2b9037fa21caaf6855420999bb6a3969c938783R1-R6)