### PR TITLE
fix(oid-federation): reduce required fields in Request Object client_metadata

### DIFF
--- a/packages/oid-federation/src/metadata/entity/v1.3/__tests__/itWalletCredentialVerifier.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/__tests__/itWalletCredentialVerifier.test.ts
@@ -39,13 +39,23 @@ const validV1_3Metadata = {
 
 describe("itWalletCredentialVerifierMetadata (v1.3)", () => {
   describe("basic validation", () => {
-    it("should validate correct v1.3.3 metadata", () => {
+    it("should validate correct v1.3.3 metadata with all fields", () => {
       const result =
         itWalletCredentialVerifierMetadata.safeParse(validV1_3Metadata);
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data).toEqual(validV1_3Metadata);
       }
+    });
+
+    it("should validate correct v1.3.3 metadata with required fields only", () => {
+      const result =
+        itWalletCredentialVerifierMetadata.safeParse({
+          encrypted_response_enc_values_supported: validV1_3Metadata.encrypted_response_enc_values_supported,
+          jwks: validV1_3Metadata.jwks,
+          vp_formats_supported: validV1_3Metadata.vp_formats_supported,
+        });
+      expect(result.success).toBe(true);
     });
   });
 
@@ -67,16 +77,6 @@ describe("itWalletCredentialVerifierMetadata (v1.3)", () => {
       };
       const result = itWalletCredentialVerifierMetadata.safeParse(
         metadataWithInvalidLogoUri,
-      );
-      expect(result.success).toBe(false);
-    });
-
-    it("should reject missing logo_uri", () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { logo_uri: _logo_uri, ...metadataWithoutLogoUri } =
-        validV1_3Metadata;
-      const result = itWalletCredentialVerifierMetadata.safeParse(
-        metadataWithoutLogoUri,
       );
       expect(result.success).toBe(false);
     });

--- a/packages/oid-federation/src/metadata/entity/v1.3/__tests__/itWalletCredentialVerifier.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/__tests__/itWalletCredentialVerifier.test.ts
@@ -49,12 +49,12 @@ describe("itWalletCredentialVerifierMetadata (v1.3)", () => {
     });
 
     it("should validate correct v1.3.3 metadata with required fields only", () => {
-      const result =
-        itWalletCredentialVerifierMetadata.safeParse({
-          encrypted_response_enc_values_supported: validV1_3Metadata.encrypted_response_enc_values_supported,
-          jwks: validV1_3Metadata.jwks,
-          vp_formats_supported: validV1_3Metadata.vp_formats_supported,
-        });
+      const result = itWalletCredentialVerifierMetadata.safeParse({
+        encrypted_response_enc_values_supported:
+          validV1_3Metadata.encrypted_response_enc_values_supported,
+        jwks: validV1_3Metadata.jwks,
+        vp_formats_supported: validV1_3Metadata.vp_formats_supported,
+      });
       expect(result.success).toBe(true);
     });
   });

--- a/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialVerifier.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialVerifier.ts
@@ -21,15 +21,15 @@ import { jsonWebKeySetSchema } from "../../../jwk/jwk";
  * @see {@link https://italia.github.io/eidas-it-wallet-docs/versioned_docs/version-1.3.3/en/relying-party-metadata.html}
  */
 export const itWalletCredentialVerifierMetadata = z.looseObject({
-  application_type: z.literal("web"),
-  client_id: z.url(),
-  client_name: z.string(),
+  application_type: z.literal("web").optional(),
+  client_id: z.url().optional(),
+  client_name: z.string().optional(),
   encrypted_response_enc_values_supported: z.array(z.string()).min(1),
   erasure_endpoint: z.url().optional(),
   jwks: jsonWebKeySetSchema,
-  logo_uri: z.url(),
-  request_uris: z.array(z.url()),
-  response_uris: z.array(z.url()),
+  logo_uri: z.url().optional(),
+  request_uris: z.array(z.url()).optional(),
+  response_uris: z.array(z.url()).optional(),
   vp_formats_supported: z.record(
     z.string(),
     z.object({


### PR DESCRIPTION
This PR changes some fields from required to optional in the `client_metadata` of v1.3 Request Object.
- `application_type`
- `client_id`
- `client_name`
- `logo_uri`
- `request_uris`
- `response_uris`

The client metadata now fully aligns with the shape defined in the [IT-Wallet Remote Presentation specification](https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/remote-flow.html#request-object).