### PR TITLE
fix(oid4vp): reduce required fields in Request Object client_metadata

### DIFF
--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -62,9 +62,6 @@ const wrongSignature =
 const correctRequestObject: Openid4vpAuthorizationRequestPayload = {
   client_id: "test-client-id",
   client_metadata: {
-    application_type: "web",
-    client_id: "https://relying-party.example.org",
-    client_name: "Example Relying Party",
     encrypted_response_enc_values_supported: ["A256GCM"],
     jwks: {
       keys: [
@@ -78,9 +75,6 @@ const correctRequestObject: Openid4vpAuthorizationRequestPayload = {
         },
       ],
     },
-    logo_uri: "https://relying-party.example.org/public/compact-logo.svg",
-    request_uris: ["https://relying-party.example.org/request_uri"],
-    response_uris: ["https://relying-party.example.org/response_uri"],
     vp_formats_supported: {
       "dc+sd-jwt": {
         "kb-jwt_alg_values": ["ES256"],

--- a/packages/oid4vp/src/authorization-request/z-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/z-authorization-request.ts
@@ -13,14 +13,15 @@ import { z } from "zod";
  * only a subset of the Credential Verifier metadata fields are required in the Request Object.
  * @see https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/remote-flow.html#request-object
  */
-const zOpenid4vpCredentialVerifierMetadata = itWalletCredentialVerifierMetadataV1_3.partial({
-  application_type: true,
-  client_id: true,
-  client_name: true,
-  logo_uri: true,
-  request_uris: true,
-  response_uris: true,
-})
+const zOpenid4vpCredentialVerifierMetadata =
+  itWalletCredentialVerifierMetadataV1_3.partial({
+    application_type: true,
+    client_id: true,
+    client_name: true,
+    logo_uri: true,
+    request_uris: true,
+    response_uris: true,
+  });
 
 /**
  * Zod parser that describes a JWT payload

--- a/packages/oid4vp/src/authorization-request/z-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/z-authorization-request.ts
@@ -9,13 +9,27 @@ import { itWalletCredentialVerifierMetadataV1_3 } from "@pagopa/io-wallet-oid-fe
 import { z } from "zod";
 
 /**
+ * This schema is a less strict version of {@link itWalletCredentialVerifierMetadataV1_3} because
+ * only a subset of the Credential Verifier metadata fields are required in the Request Object.
+ * @see https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/remote-flow.html#request-object
+ */
+const zOpenid4vpCredentialVerifierMetadata = itWalletCredentialVerifierMetadataV1_3.partial({
+  application_type: true,
+  client_id: true,
+  client_name: true,
+  logo_uri: true,
+  request_uris: true,
+  response_uris: true,
+})
+
+/**
  * Zod parser that describes a JWT payload
  * containing an OID4VP Request Object
  */
 export const zOpenid4vpAuthorizationRequestPayload = z
   .looseObject({
     client_id: z.string(),
-    client_metadata: itWalletCredentialVerifierMetadataV1_3.optional(),
+    client_metadata: zOpenid4vpCredentialVerifierMetadata.optional(),
     dcql_query: z.record(z.string(), z.any()),
     nonce: z.string(),
     request_uri: z.url().optional(),


### PR DESCRIPTION
This PR changes some fields from required to optional in the `client_metadata` of v1.3 Request Object:
- `application_type`
- `client_id`
- `client_name`
- `logo_uri`
- `request_uris`
- `response_uris`

The client metadata now fully aligns with the shape defined in the [IT-Wallet Remote Presentation specification](https://italia.github.io/eid-wallet-it-docs/releases/1.3.3/en/remote-flow.html#request-object).