### PR TITLE
docs: Improve README with badges, callback pattern, and package guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # IO Wallet SDK
 
+[![CI](https://github.com/pagopa/io-wallet-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/pagopa/io-wallet-sdk/actions)
+[![npm](https://img.shields.io/npm/v/@pagopa/io-wallet-utils?label=latest)](https://www.npmjs.com/search?q=%40pagopa%2Fio-wallet)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+
 A comprehensive TypeScript library for building applications that integrate with **Italy's national digital identity wallet**. 🇮🇹
 
 This SDK provides all the necessary tools to handle Verifiable Credentials and secure interactions according to the official Italian specifications, which are based on **OpenID for Verifiable Credentials (OpenID4VC)** and **OAuth 2.0** standards. It builds upon the foundation of the [oid4vc-ts](https://github.com/openwallet-foundation-labs/oid4vc-ts) library from the OpenWallet Foundation, extending it to meet the specific requirements of the Italian digital ecosystem.
@@ -8,7 +12,7 @@ The project is structured as a monorepo using `pnpm` and is designed to be envir
 
 ## Key Features
 
-- **Full IT-Wallet Compliance**: Implements the specific profiles and flows required by the official [IT Wallet specifications](https://italia.github.io/eid-wallet-it-docs/releases/1.0.2/en/), currently 1.0.2 version.
+- **Full IT-Wallet Compliance**: Implements the specific profiles and flows required by the official [IT Wallet specifications](https://italia.github.io/eid-wallet-it-docs/en/), supporting versions **V1.0**, **V1.3**, and **V1.4**.
 - **Modern & Secure**: Built with TypeScript and includes support for modern OAuth 2.0 extensions like `PAR`, `DPoP`, and `PKCE`.
 - **Modular Architecture**: The core logic is split into scoped packages, so you only use what you need.
 - **Crypto Agnostic**: Does not impose a specific cryptographic library.
@@ -19,22 +23,70 @@ This SDK is a monorepo containing the following packages:
 
 | Package                                | Description                                                                                                                                               |
 | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`@pagopa/io-wallet-oauth2`**         | Implements core OAuth 2.0 flows and security extensions (PAR, DPoP, PKCE, JARM) required for secure interactions.                                         |
-| **`@pagopa/io-wallet-oid-federation`** | Handles entity discovery and trust chain resolution within the Italian Federation, ensuring all actors are trusted and valid. 🛡️                          |
+| **`@pagopa/io-wallet-oauth2`**         | Implements core OAuth 2.0 flows and security extensions (PAR, DPoP, PKCE, JARM) required for secure interactions.                                        |
+| **`@pagopa/io-wallet-oid-federation`** | Handles entity discovery and trust chain resolution within the Italian Federation, ensuring all actors are trusted and valid.                              |
 | **`@pagopa/io-wallet-oid4vci`**        | Manages **Verifiable Credential Issuance** flows. Use this to build Issuer services for credentials like the `mso_mdoc` (e.g., Digital Driver's License). |
-| **`@pagopa/io-wallet-oid4vp`**         | Manages **Verifiable Presentation** flows. Use this to build Relying Party services that request and verify user credentials from the IT-Wallet. ✅       |
+| **`@pagopa/io-wallet-oid4vp`**         | Manages **Verifiable Presentation** flows. Use this to build Relying Party services that request and verify user credentials from the IT-Wallet.          |
+| **`@pagopa/io-wallet-utils`**          | Shared types, configuration (`IoWalletSdkConfig`, `ItWalletSpecsVersion`), and utilities used across all packages.                                        |
+
+## Which packages do I need?
+
+The IT-Wallet ecosystem has three distinct actor roles. Install only the packages relevant to your use case.
+
+| Role | Description | Packages |
+| ---- | ----------- | -------- |
+| **Relying Party** (Verifier) | Requests and verifies credentials from a user's wallet | `@pagopa/io-wallet-oid4vp`, `@pagopa/io-wallet-oid-federation` |
+| **Credential Issuer** | Issues Verifiable Credentials to a wallet | `@pagopa/io-wallet-oid4vci`, `@pagopa/io-wallet-oid-federation` |
+| **Wallet Provider** | Manages wallet instance lifecycle and attestations | `@pagopa/io-wallet-oid4vci`, `@pagopa/io-wallet-oauth2`, `@pagopa/io-wallet-oid-federation` |
+
+All roles require `@pagopa/io-wallet-utils` for shared configuration types.
 
 ## Installation
 
-To get started, install the packages you need for your project using `pnpm`.
+Install the packages for your role:
 
 ```bash
-# To build a Relying Party (Verifier)
-pnpm add @it-wallet-sdk/oid4vp @it-wallet-sdk/oid-federation
+# Relying Party (Verifier)
+pnpm add @pagopa/io-wallet-oid4vp @pagopa/io-wallet-oid-federation @pagopa/io-wallet-utils
 
-# To build an Issuer
-pnpm add @it-wallet-sdk/oid4vci @it-wallet-sdk/oid-federation
+# Credential Issuer
+pnpm add @pagopa/io-wallet-oid4vci @pagopa/io-wallet-oid-federation @pagopa/io-wallet-utils
+
+# Wallet Provider
+pnpm add @pagopa/io-wallet-oid4vci @pagopa/io-wallet-oauth2 @pagopa/io-wallet-oid-federation @pagopa/io-wallet-utils
 ```
+
+## Callback Pattern
+
+This SDK is **crypto-agnostic and environment-agnostic**. Instead of bundling a specific cryptographic library or HTTP client, every function that needs to sign JWTs, hash data, or make HTTP requests accepts a `callbacks` object where you provide your own implementations.
+
+This makes the SDK compatible with Node.js, browsers, and React Native without modification.
+
+```typescript
+import { createTokenDPoP } from '@pagopa/io-wallet-oauth2';
+
+const result = await createTokenDPoP({
+  // Provide your own implementations for cryptographic operations
+  callbacks: {
+    signJwt: async (signer, { header, payload }) => {
+      // Use any JWT library or hardware key (e.g. node-jose, jose, HSM)
+      return myJwtLibrary.sign(header, payload, myPrivateKey);
+    },
+    hash: async (data, algorithm) => {
+      // Use any hash implementation (e.g. SubtleCrypto, node:crypto)
+      return crypto.subtle.digest(algorithm, data);
+    },
+    generateRandom: async (byteLength) => {
+      // Use any CSPRNG available in your environment
+      return crypto.getRandomValues(new Uint8Array(byteLength));
+    },
+  },
+  signer: { method: 'jwk', publicJwk: myPublicJwk, alg: 'ES256' },
+  tokenRequest: { method: 'POST', url: 'https://issuer.example.com/token' },
+});
+```
+
+Each function documents exactly which callbacks it requires via TypeScript's `Pick<CallbackContext, ...>`, so you only implement what is needed.
 
 ## Development
 
@@ -63,17 +115,17 @@ To set up the repository for local development:
 
 The SDK supports multiple versions of the Italian Wallet technical specifications. You must configure the version in some methods using `IoWalletSdkConfig`.
 
+| Spec Version | Status |
+| ------------ | ------ |
+| V1.0         | Supported |
+| V1.3         | Supported |
+| V1.4         | Supported |
+
 ```typescript
 import { IoWalletSdkConfig, ItWalletSpecsVersion } from '@pagopa/io-wallet-utils';
 
-// Create a configuration for IT-Wallet v1.0
-const configV1_0 = new IoWalletSdkConfig({
-  itWalletSpecsVersion: ItWalletSpecsVersion.V1_0
-});
-
-// Create a configuration for IT-Wallet v1.3
-const configV1_3 = new IoWalletSdkConfig({
-  itWalletSpecsVersion: ItWalletSpecsVersion.V1_3
+const config = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_4 // or V1_0, V1_3
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 [![CI](https://github.com/pagopa/io-wallet-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/pagopa/io-wallet-sdk/actions)
 [![npm](https://img.shields.io/npm/v/@pagopa/io-wallet-utils?label=latest)](https://www.npmjs.com/search?q=%40pagopa%2Fio-wallet)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 A comprehensive TypeScript library for building applications that integrate with **Italy's national digital identity wallet**. 🇮🇹
 
-This SDK provides all the necessary tools to handle Verifiable Credentials and secure interactions according to the official Italian specifications, which are based on **OpenID for Verifiable Credentials (OpenID4VC)** and **OAuth 2.0** standards. It builds upon the foundation of the [oid4vc-ts](https://github.com/openwallet-foundation-labs/oid4vc-ts) library from the OpenWallet Foundation, extending it to meet the specific requirements of the Italian digital ecosystem.
+This SDK provides all the necessary tools to handle Verifiable Credentials and secure interactions according to the official Italian specifications, which are based on **OpenID for Verifiable Credentials (OpenID4VC)** and **OAuth 2.0** standards. 
 
 The project is structured as a monorepo using `pnpm` and is designed to be environment-agnostic (Node.js, Browser, React Native), allowing you to build services for Relying Parties, Issuers, and Wallets.
 
@@ -136,3 +135,11 @@ const config = new IoWalletSdkConfig({
 ## 🧭 Contribute
 
 For internal development conventions and contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the Apache License Version 2.0 (Apache-2.0).
+
+## Credits
+
+It builds upon the foundation of the [oid4vc-ts](https://github.com/openwallet-foundation-labs/oid4vc-ts) library from the OpenWallet Foundation, extending it to meet the specific requirements of the Italian digital ecosystem.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ const result = await createTokenDPoP({
     },
     hash: async (data, algorithm) => {
       // Use any hash implementation (e.g. SubtleCrypto, node:crypto)
-      return crypto.subtle.digest(algorithm, data);
+      const digest = await crypto.subtle.digest(algorithm, data);
+      return new Uint8Array(digest);
     },
     generateRandom: async (byteLength) => {
       // Use any CSPRNG available in your environment

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ const result = await createTokenDPoP({
   callbacks: {
     signJwt: async (signer, { header, payload }) => {
       // Use any JWT library or hardware key (e.g. node-jose, jose, HSM)
-      return myJwtLibrary.sign(header, payload, myPrivateKey);
+      return {
+        jwt: myJwtLibrary.sign(header, payload, myPrivateKey),
+        signerJwk: myPublicJwk,
+      };
     },
     hash: async (data, algorithm) => {
       // Use any hash implementation (e.g. SubtleCrypto, node:crypto)


### PR DESCRIPTION
Enhances the root README.md to make it easier for new consumers to get started and understand the SDK's design principles.

### Changes


- Added CI status, npm version, and license badges to the top of the README.

- Added the missing @pagopa/io-wallet-utils package to the packages table with a description of its role (shared config types and utilities).
- Removed decorative emojis from table cells for consistency.

- Added a role-based guide (Relying Party, Credential Issuer, Wallet Provider) mapping each actor to the packages they should install.
- Corrected the installation commands to use the correct @pagopa/io-wallet-* scoped package names (previously listed under the wrong @it-wallet-sdk/* scope).

- Added a dedicated section explaining the SDK's crypto-agnostic and environment-agnostic design.
- Includes a concrete code example showing how to provide signJwt, hash, and generateRandom callbacks, with references to platform-specific implementations.

- Replaced the two separate IoWalletSdkConfig examples with a single concise example preceded by a status table showing all supported spec versions (V1.0, V1.3, V1.4).
- Updated the IT-Wallet specs link to point to the version-agnostic docs URL