### PR TITLE
fix: make state field optional in OpenID4VP authorization request payload

### DIFF
--- a/.changeset/large-humans-shop.md
+++ b/.changeset/large-humans-shop.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid4vp": patch
+---
+
+make state field optional in OpenID4VP authorization request payload

--- a/packages/oid4vp/src/authorization-request/__tests__/create-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/create-authorization-request.test.ts
@@ -240,7 +240,7 @@ describe("createAuthorizationRequest", () => {
       createAuthorizationRequest({
         authorizationRequestPayload: {
           ...authorizationRequestPayload,
-          state: undefined as unknown as string,
+          nonce: undefined as unknown as string,
         },
         callbacks,
         config: configV1_0,
@@ -252,7 +252,7 @@ describe("createAuthorizationRequest", () => {
       createAuthorizationRequest({
         authorizationRequestPayload: {
           ...authorizationRequestPayload,
-          state: undefined as unknown as string,
+          nonce: undefined as unknown as string,
         },
         callbacks,
         config: configV1_0,

--- a/packages/oid4vp/src/authorization-request/__tests__/z-request-object.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/z-request-object.test.ts
@@ -21,11 +21,6 @@ describe("zOpenid4vpAuthorizationRequestPayload", () => {
     expect(result.success).toBe(true);
   });
 
-  it("should fail when iss is missing", () => {
-    const result = zOpenid4vpAuthorizationRequestPayload.safeParse(basePayload);
-    expect(result.success).toBe(false);
-  });
-
   it("should fail when iss is not a string", () => {
     const result = zOpenid4vpAuthorizationRequestPayload.safeParse({
       ...basePayload,

--- a/packages/oid4vp/src/authorization-request/z-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/z-authorization-request.ts
@@ -39,7 +39,7 @@ export const zOpenid4vpAuthorizationRequestPayload = z
     response_type: z.literal("vp_token"),
     response_uri: z.url(),
     scope: z.string().optional(),
-    state: z.string(),
+    state: z.string().optional(),
     transaction_data: z.array(z.string()).nonempty().optional(),
     transaction_data_hashes_alg: z.array(z.string()).optional(),
     wallet_nonce: z.string().optional(),
@@ -47,7 +47,6 @@ export const zOpenid4vpAuthorizationRequestPayload = z
   .and(
     z.object({
       ...zJwtPayload.shape,
-      iss: z.string(),
     }),
   );
 

--- a/packages/oid4vp/src/authorization-response/z-authorization-response.ts
+++ b/packages/oid4vp/src/authorization-response/z-authorization-response.ts
@@ -3,7 +3,7 @@ import z from "zod";
 import { zVpToken } from "../vp-token/z-vp-token";
 
 export const zOpenid4vpAuthorizationResponse = z.object({
-  state: z.string(),
+  state: z.string().optional(),
   vp_token: zVpToken,
 });
 

--- a/packages/oid4vp/src/jarm/verify-jarm-authorization-response.ts
+++ b/packages/oid4vp/src/jarm/verify-jarm-authorization-response.ts
@@ -187,7 +187,7 @@ export async function verifyJarmAuthorizationResponse(
       );
     }
 
-    if (response.iss !== expectedIssuer) {
+    if (expectedIssuer && response.iss !== expectedIssuer) {
       throw new Oauth2Error(
         `Jarm Auth Response contains 'iss' value '${response.iss}', but expected '${expectedIssuer}'.`,
       );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
`state` and `iss` as optional in `zOpenid4vpAuthorizationRequestPayload`

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

`state` is RECOMMENDED in IT Wallet Spec. 
I remove `iss` as mandatory to improve interoperability with OpenID4VP 1.0. OpenID4VP Conformance Test does not include iss in request object.

Reference https://italia.github.io/eid-wallet-it-docs/versione-corrente/en/remote-flow.html

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
