### PR TITLE
fix(oid4vp): extractClientIdPrefix to handle HTTPS URLs

### DIFF
--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -563,6 +563,13 @@ describe("extractClientIdPrefix", () => {
     });
   });
 
+  it("returns NONE prefix and full URL when client_id is a https URL", () => {
+    expect(extractClientIdPrefix("https://client.example.it")).toEqual({
+      clientId: "https://client.example.it",
+      prefix: ClientIdPrefix.NONE,
+    });
+  });
+
   it("handles value containing additional colons correctly", () => {
     expect(extractClientIdPrefix("x509_hash:a:b:c")).toEqual({
       clientId: "a:b:c",

--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -570,6 +570,19 @@ describe("extractClientIdPrefix", () => {
     });
   });
 
+  it("returns NONE prefix and full URL when client_id is an http URL", () => {
+    expect(extractClientIdPrefix("http://client.example.it")).toEqual({
+      clientId: "http://client.example.it",
+      prefix: ClientIdPrefix.NONE,
+    });
+  });
+
+  it("throws Oid4vpError for a URL-like prefix that is not http or https", () => {
+    expect(() => extractClientIdPrefix("ftp://client.example.it")).toThrow(
+      Oid4vpError,
+    );
+  });
+
   it("handles value containing additional colons correctly", () => {
     expect(extractClientIdPrefix("x509_hash:a:b:c")).toEqual({
       clientId: "a:b:c",

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -47,7 +47,8 @@ export interface ClientIdParts {
 export function extractClientIdPrefix(clientId: string): ClientIdParts {
   const colonIndex = clientId.indexOf(":");
 
-  if (colonIndex === -1) {
+  // No colon, or the colon is part of a URI scheme (e.g. "https://...") → no prefix
+  if (colonIndex === -1 || clientId.slice(colonIndex + 1).startsWith("//")) {
     return { clientId, prefix: ClientIdPrefix.NONE };
   }
 

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -47,8 +47,13 @@ export interface ClientIdParts {
 export function extractClientIdPrefix(clientId: string): ClientIdParts {
   const colonIndex = clientId.indexOf(":");
 
-  // No colon, or the colon is part of a URI scheme (e.g. "https://...") → no prefix
-  if (colonIndex === -1 || clientId.slice(colonIndex + 1).startsWith("//")) {
+  // No colon → no prefix
+  if (colonIndex === -1) {
+    return { clientId, prefix: ClientIdPrefix.NONE };
+  }
+
+  // Explicitly allow HTTP(S) URL client_id values without treating the scheme as a prefix.
+  if (clientId.startsWith("https://") || clientId.startsWith("http://")) {
     return { clientId, prefix: ClientIdPrefix.NONE };
   }
 


### PR DESCRIPTION
#### List of Changes
- Updated `extractClientIdPrefix` function to correctly identify HTTPS URLs without prefixes.
- Added a test case to validate the new behavior for HTTPS URLs.

#### Motivation and Context
This change addresses the need for the `extractClientIdPrefix` function to handle client IDs that are HTTPS URLs. Previously, such URLs were not processed correctly, potentially leading to incorrect prefix assignments.

#### How Has This Been Tested?
The changes were tested by adding a new test case that checks the function's output when provided with an HTTPS URL. The test confirms that the function returns the full URL with the correct prefix.

