### PR TITLE
chore(oid-federation): allow legacy it_spid in trust_frameworks_supported 1.3 for backward compatibility

### DIFF
--- a/.changeset/whole-points-take.md
+++ b/.changeset/whole-points-take.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid-federation": patch
+---
+
+Allow it_spid in Credential Issuer v1.3 trust_frameworks_supported for backward compatibility

--- a/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
@@ -163,6 +163,8 @@ export const itWalletCredentialIssuerMetadata = z.looseObject({
       z.literal("it_cie"),
       z.literal("it_wallet"),
       z.literal("it_l2+document_proof"),
+      /** @deprecated For backward compatibility only, will be removed in future versions. */
+      z.literal("it_spid"),
     ]),
   ),
 });


### PR DESCRIPTION
#### List of Changes

- Allow "it_spid" in the Credential Issuer v1.3 metadata-`trust_frameworks_supported`- for backward compatibility. 
