### PR TITLE
fix(oid-federation): Allow numeric values in credential_signing_alg_values_supported for mdoc credentials

### DIFF
--- a/.changeset/afraid-dolls-bet.md
+++ b/.changeset/afraid-dolls-bet.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid-federation": patch
+---
+
+Allow numeric values in credential_signing_alg_values_supported for mdoc credentials (Issuer metadata v1.3)

--- a/packages/oid-federation/src/metadata/entity/v1.3/__tests__/itWalletCredentialIssuer.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/__tests__/itWalletCredentialIssuer.test.ts
@@ -171,7 +171,7 @@ describe("itWalletCredentialIssuerMetadata v1.3 metadata", () => {
               },
             ],
           },
-          credential_signing_alg_values_supported: ["ES256"],
+          credential_signing_alg_values_supported: [-7],
           cryptographic_binding_methods_supported: ["cose_key"],
           doctype: "org.iso.18013.5.1.mDL",
           format: "mso_mdoc",

--- a/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
@@ -119,7 +119,7 @@ export const SupportedCredentialMetadata = z.intersection(
       vct: z.string(),
     }),
     z.object({
-      credential_signing_alg_values_supported: z.array(z.number()),
+      credential_signing_alg_values_supported: z.array(z.number().int()),
       doctype: z.string(),
       format: z.literal("mso_mdoc"),
     }),

--- a/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
@@ -113,13 +113,20 @@ export type SupportedCredentialMetadata = z.infer<
 
 export const SupportedCredentialMetadata = z.intersection(
   z.discriminatedUnion("format", [
-    z.object({ format: z.literal("dc+sd-jwt"), vct: z.string() }),
-    z.object({ doctype: z.string(), format: z.literal("mso_mdoc") }),
+    z.object({
+      credential_signing_alg_values_supported: z.array(z.string()),
+      format: z.literal("dc+sd-jwt"),
+      vct: z.string(),
+    }),
+    z.object({
+      credential_signing_alg_values_supported: z.array(z.number()),
+      doctype: z.string(),
+      format: z.literal("mso_mdoc"),
+    }),
   ]),
   z.object({
     authentic_sources: AuthenticSources,
     credential_metadata: CredentialMetadata,
-    credential_signing_alg_values_supported: z.array(z.string()),
     cryptographic_binding_methods_supported: z.array(z.string()),
     proof_types_supported: ProofTypesSupported,
     schema_id: z.string(),


### PR DESCRIPTION
This PR fixes the type of values for `credential_signing_alg_values_supported` of mdoc credentials, changing it from string to number in accordance with OpenID4VCI [Credential Issuance Metadata](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata-5) for `mso_mdoc` format.

