### PR TITLE
fix(oid4vci): add duplicated proof keys validation in parseCredentialRequest

### DIFF
--- a/.changeset/clean-cameras-burn.md
+++ b/.changeset/clean-cameras-burn.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid4vci": minor
+---
+
+Add batch proof JWK uniqueness validation to credential request parsing

--- a/packages/oid4vci/src/credential-request/__tests__/parse-credential-request.test.ts
+++ b/packages/oid4vci/src/credential-request/__tests__/parse-credential-request.test.ts
@@ -16,6 +16,20 @@ import { parseCredentialRequest } from "../parse-credential-request";
 const VALID_DPOP_JWT =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6ImRwb3Arand0In0.eyJodG0iOiJQT1NUIiwiaHR1IjoiaHR0cHM6Ly9pc3N1ZXIuZXhhbXBsZS5jb20vY3JlZGVudGlhbCIsImlhdCI6MTcwMDAwMDAwMH0.signature";
 
+const PROOF_JWK = {
+  crv: "P-256",
+  kty: "EC",
+  x: "test-x-coordinate-1",
+  y: "test-y-coordinate-1",
+};
+
+const SECOND_PROOF_JWK = {
+  crv: "P-256",
+  kty: "EC",
+  x: "test-x-coordinate-2",
+  y: "test-y-coordinate-2",
+};
+
 function createHeaders(options?: {
   authorization?: string;
   dpop?: string;
@@ -37,9 +51,7 @@ function createJwt(options?: {
   const header = Buffer.from(
     JSON.stringify({
       alg: "ES256",
-      jwk: {
-        kty: "EC",
-      },
+      jwk: PROOF_JWK,
       typ: "openid4vci-proof+jwt",
       ...options?.header,
     }),
@@ -63,11 +75,13 @@ function createProofJwt(payload?: Record<string, unknown>): string {
 }
 
 function createProofJwtV1_3(options?: {
+  jwk?: Record<string, unknown>;
   keyAttestation?: string;
   payload?: Record<string, unknown>;
 }): string {
   return createJwt({
     header: {
+      jwk: options?.jwk ?? PROOF_JWK,
       key_attestation: options?.keyAttestation ?? "test-key-attestation",
     },
     payload: options?.payload,
@@ -120,7 +134,10 @@ describe("parseCredentialRequest", () => {
         proofs: {
           jwt: [
             createProofJwtV1_3(),
-            createProofJwtV1_3({ payload: { nonce: "test-nonce-2" } }),
+            createProofJwtV1_3({
+              jwk: SECOND_PROOF_JWK,
+              payload: { nonce: "test-nonce-2" },
+            }),
           ],
         },
       },
@@ -136,6 +153,35 @@ describe("parseCredentialRequest", () => {
     expect(result.proofs[0]?.payload.aud).toBe("https://issuer.example.com");
     expect(result.proofs[1]?.payload.nonce).toBe("test-nonce-2");
   });
+
+  it.each([ItWalletSpecsVersion.V1_3, ItWalletSpecsVersion.V1_4])(
+    "throws ValidationError when batch credential request contains duplicate proof JWKs (%s)",
+    (itWalletSpecsVersion) => {
+      const config = new IoWalletSdkConfig({ itWalletSpecsVersion });
+
+      expect(() =>
+        parseCredentialRequest({
+          config,
+          credentialRequest: {
+            credential_identifier: "education_degree",
+            proofs: {
+              jwt: [
+                createProofJwtV1_3({ jwk: { ...PROOF_JWK, kid: "key-1" } }),
+                createProofJwtV1_3({
+                  jwk: { ...PROOF_JWK, kid: "key-2" },
+                  payload: { nonce: "test-nonce-2" },
+                }),
+              ],
+            },
+          },
+          headers: createHeaders({
+            authorization: "DPoP test-access-token",
+            dpop: VALID_DPOP_JWT,
+          }),
+        }),
+      ).toThrow(ValidationError);
+    },
+  );
 
   it("parses v1.4 credential request and returns itWalletSpecsVersion V1_4", () => {
     const config = new IoWalletSdkConfig({

--- a/packages/oid4vci/src/credential-request/__tests__/parse-credential-request.test.ts
+++ b/packages/oid4vci/src/credential-request/__tests__/parse-credential-request.test.ts
@@ -11,7 +11,11 @@ import {
   CredentialAuthorizationHeaderError,
   MissingDpopProofError,
 } from "../../errors";
-import { parseCredentialRequest } from "../parse-credential-request";
+import {
+  type ParseCredentialRequestOptions,
+  type ParsedCredentialRequest,
+  parseCredentialRequest,
+} from "../parse-credential-request";
 
 const VALID_DPOP_JWT =
   "eyJhbGciOiJFUzI1NiIsInR5cCI6ImRwb3Arand0In0.eyJodG0iOiJQT1NUIiwiaHR1IjoiaHR0cHM6Ly9pc3N1ZXIuZXhhbXBsZS5jb20vY3JlZGVudGlhbCIsImlhdCI6MTcwMDAwMDAwMH0.signature";
@@ -88,14 +92,27 @@ function createProofJwtV1_3(options?: {
   });
 }
 
+const callbacks = {
+  hash: (data: Uint8Array): Uint8Array => data,
+};
+
+function parseTestCredentialRequest(
+  options: Omit<ParseCredentialRequestOptions, "callbacks">,
+): Promise<ParsedCredentialRequest> {
+  return parseCredentialRequest({
+    callbacks,
+    ...options,
+  });
+}
+
 describe("parseCredentialRequest", () => {
-  it("parses and normalizes v1.0 credential request", () => {
+  it("parses and normalizes v1.0 credential request", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
     const jwt = createProofJwt();
 
-    const result = parseCredentialRequest({
+    const result = await parseTestCredentialRequest({
       config,
       credentialRequest: {
         credential_identifier: "UniversityDegree",
@@ -122,12 +139,12 @@ describe("parseCredentialRequest", () => {
     );
   });
 
-  it("parses and normalizes v1.3 credential request with multiple proofs", () => {
+  it("parses and normalizes v1.3 credential request with multiple proofs", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    const result = parseCredentialRequest({
+    const result = await parseTestCredentialRequest({
       config,
       credentialRequest: {
         credential_identifier: "education_degree",
@@ -156,11 +173,11 @@ describe("parseCredentialRequest", () => {
 
   it.each([ItWalletSpecsVersion.V1_3, ItWalletSpecsVersion.V1_4])(
     "throws ValidationError when batch credential request contains duplicate proof JWKs (%s)",
-    (itWalletSpecsVersion) => {
+    async (itWalletSpecsVersion) => {
       const config = new IoWalletSdkConfig({ itWalletSpecsVersion });
 
-      expect(() =>
-        parseCredentialRequest({
+      await expect(
+        parseTestCredentialRequest({
           config,
           credentialRequest: {
             credential_identifier: "education_degree",
@@ -179,16 +196,16 @@ describe("parseCredentialRequest", () => {
             dpop: VALID_DPOP_JWT,
           }),
         }),
-      ).toThrow(ValidationError);
+      ).rejects.toThrow(ValidationError);
     },
   );
 
-  it("parses v1.4 credential request and returns itWalletSpecsVersion V1_4", () => {
+  it("parses v1.4 credential request and returns itWalletSpecsVersion V1_4", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_4,
     });
 
-    const result = parseCredentialRequest({
+    const result = await parseTestCredentialRequest({
       config,
       credentialRequest: {
         credential_identifier: "education_degree",
@@ -207,13 +224,13 @@ describe("parseCredentialRequest", () => {
     expect(result.proofs).toHaveLength(1);
   });
 
-  it("throws MissingDpopProofError when DPoP header is absent (v1.0)", () => {
+  it("throws MissingDpopProofError when DPoP header is absent (v1.0)", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -226,16 +243,16 @@ describe("parseCredentialRequest", () => {
           authorization: "DPoP test-access-token",
         }),
       }),
-    ).toThrow(MissingDpopProofError);
+    ).rejects.toThrow(MissingDpopProofError);
   });
 
-  it("throws MissingDpopProofError when DPoP header is absent (v1.3)", () => {
+  it("throws MissingDpopProofError when DPoP header is absent (v1.3)", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "education_degree",
@@ -247,16 +264,16 @@ describe("parseCredentialRequest", () => {
           authorization: "DPoP test-access-token",
         }),
       }),
-    ).toThrow(MissingDpopProofError);
+    ).rejects.toThrow(MissingDpopProofError);
   });
 
-  it("throws MissingDpopProofError when DPoP header value is not a valid JWT", () => {
+  it("throws MissingDpopProofError when DPoP header value is not a valid JWT", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -270,16 +287,16 @@ describe("parseCredentialRequest", () => {
           dpop: "not-a-jwt",
         }),
       }),
-    ).toThrow(MissingDpopProofError);
+    ).rejects.toThrow(MissingDpopProofError);
   });
 
-  it("throws CredentialAuthorizationHeaderError when Authorization header is absent", () => {
+  it("throws CredentialAuthorizationHeaderError when Authorization header is absent", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -292,16 +309,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(CredentialAuthorizationHeaderError);
+    ).rejects.toThrow(CredentialAuthorizationHeaderError);
   });
 
-  it("throws CredentialAuthorizationHeaderError when Authorization scheme is Bearer", () => {
+  it("throws CredentialAuthorizationHeaderError when Authorization scheme is Bearer", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "education_degree",
@@ -314,16 +331,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(CredentialAuthorizationHeaderError);
+    ).rejects.toThrow(CredentialAuthorizationHeaderError);
   });
 
-  it("throws CredentialAuthorizationHeaderError when Authorization token is missing", () => {
+  it("throws CredentialAuthorizationHeaderError when Authorization token is missing", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -337,16 +354,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(CredentialAuthorizationHeaderError);
+    ).rejects.toThrow(CredentialAuthorizationHeaderError);
   });
 
-  it("throws CredentialAuthorizationHeaderError when Authorization header has extra parts", () => {
+  it("throws CredentialAuthorizationHeaderError when Authorization header has extra parts", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "education_degree",
@@ -359,16 +376,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(CredentialAuthorizationHeaderError);
+    ).rejects.toThrow(CredentialAuthorizationHeaderError);
   });
 
-  it("throws ValidationError when transaction_id is present in immediate flow", () => {
+  it("throws ValidationError when transaction_id is present in immediate flow", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -383,16 +400,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when transaction_id is missing in deferred flow", () => {
+  it("throws ValidationError when transaction_id is missing in deferred flow", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "education_degree",
@@ -406,16 +423,16 @@ describe("parseCredentialRequest", () => {
         }),
         isDeferredFlow: true,
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when iss is missing for authorization_code grant", () => {
+  it("throws ValidationError when iss is missing for authorization_code grant", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -429,15 +446,15 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("allows missing iss for pre-authorized_code grant", () => {
+  it("allows missing iss for pre-authorized_code grant", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    const result = parseCredentialRequest({
+    const result = await parseTestCredentialRequest({
       config,
       credentialRequest: {
         credential_identifier: "education_degree",
@@ -455,12 +472,12 @@ describe("parseCredentialRequest", () => {
     expect(result.proofs[0]?.payload.iss).toBeUndefined();
   });
 
-  it("allows missing iss for pre-authorized_code grant even when expected issuer is provided", () => {
+  it("allows missing iss for pre-authorized_code grant even when expected issuer is provided", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    const result = parseCredentialRequest({
+    const result = await parseTestCredentialRequest({
       config,
       credentialRequest: {
         credential_identifier: "education_degree",
@@ -481,13 +498,13 @@ describe("parseCredentialRequest", () => {
     expect(result.proofs[0]?.payload.iss).toBeUndefined();
   });
 
-  it("throws ValidationError when expected audience does not match", () => {
+  it("throws ValidationError when expected audience does not match", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -504,16 +521,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when expected nonce does not match", () => {
+  it("throws ValidationError when expected nonce does not match", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -530,16 +547,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when expected credential_identifier does not match", () => {
+  it("throws ValidationError when expected credential_identifier does not match", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -556,16 +573,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when expected credential_configuration_id does not match", () => {
+  it("throws ValidationError when expected credential_configuration_id does not match", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_configuration_id: "PidCredential",
@@ -581,16 +598,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when expected issuer does not match proof issuer", () => {
+  it("throws ValidationError when expected issuer does not match proof issuer", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -607,16 +624,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when proof JWT header is invalid", () => {
+  it("throws ValidationError when proof JWT header is invalid", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -634,16 +651,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError for v1.3 when key_attestation is missing in proof JWT header", () => {
+  it("throws ValidationError for v1.3 when key_attestation is missing in proof JWT header", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "education_degree",
@@ -656,16 +673,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError for v1.3 when key_attestation is empty", () => {
+  it("throws ValidationError for v1.3 when key_attestation is empty", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "education_degree",
@@ -678,16 +695,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws ValidationError when proof JWT payload is invalid", () => {
+  it("throws ValidationError when proof JWT payload is invalid", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -705,16 +722,16 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(ValidationError);
+    ).rejects.toThrow(ValidationError);
   });
 
-  it("throws Oauth2JwtParseError when proof JWT is malformed", () => {
+  it("throws Oauth2JwtParseError when proof JWT is malformed", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
 
-    expect(() =>
-      parseCredentialRequest({
+    await expect(
+      parseTestCredentialRequest({
         config,
         credentialRequest: {
           credential_identifier: "UniversityDegree",
@@ -728,6 +745,6 @@ describe("parseCredentialRequest", () => {
           dpop: VALID_DPOP_JWT,
         }),
       }),
-    ).toThrow(Oauth2JwtParseError);
+    ).rejects.toThrow(Oauth2JwtParseError);
   });
 });

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -256,23 +256,6 @@ function parseProofJwt(options: {
   };
 }
 
-async function calculateProofJwkThumbprint(options: {
-  callbacks: Pick<CallbackContext, "hash">;
-  jwk: ProofJwtHeader["jwk"];
-}): Promise<string> {
-  try {
-    return await calculateJwkThumbprint({
-      hashAlgorithm: HashAlgorithm.Sha256,
-      hashCallback: options.callbacks.hash,
-      jwk: options.jwk,
-    });
-  } catch {
-    throw new ValidationError(
-      "Credential proof JWT jwk header does not match a supported RFC7638 JWK thumbprint structure",
-    );
-  }
-}
-
 async function validateProofJwkUniqueness(options: {
   callbacks: Pick<CallbackContext, "hash">;
   proofs: ParsedCredentialProof[];
@@ -283,8 +266,9 @@ async function validateProofJwkUniqueness(options: {
 
   const thumbprints = await Promise.all(
     options.proofs.map((proof) =>
-      calculateProofJwkThumbprint({
-        callbacks: options.callbacks,
+      calculateJwkThumbprint({
+        hashAlgorithm: HashAlgorithm.Sha256,
+        hashCallback: options.callbacks.hash,
         jwk: proof.header.jwk,
       }),
     ),

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -251,6 +251,80 @@ function parseProofJwt(options: {
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function canonicalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeJson);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.keys(value)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      const property = value[key];
+      if (property !== undefined) {
+        acc[key] = canonicalizeJson(property);
+      }
+      return acc;
+    }, {});
+}
+
+function pickJwkMembers(
+  jwk: Record<string, unknown>,
+  members: string[],
+): Record<string, unknown> | undefined {
+  if (members.some((member) => jwk[member] === undefined)) {
+    return undefined;
+  }
+
+  return members.reduce<Record<string, unknown>>((acc, member) => {
+    acc[member] = jwk[member];
+    return acc;
+  }, {});
+}
+
+function getJwkThumbprintInput(
+  jwk: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  switch (jwk.kty) {
+    case "EC":
+      return pickJwkMembers(jwk, ["crv", "kty", "x", "y"]);
+    case "OKP":
+      return pickJwkMembers(jwk, ["crv", "kty", "x"]);
+    case "RSA":
+      return pickJwkMembers(jwk, ["e", "kty", "n"]);
+    case "oct":
+      return pickJwkMembers(jwk, ["k", "kty"]);
+    default:
+      return undefined;
+  }
+}
+
+function createProofJwkUniquenessKey(jwk: unknown): string {
+  const comparableJwk = isRecord(jwk)
+    ? (getJwkThumbprintInput(jwk) ?? jwk)
+    : jwk;
+  return JSON.stringify(canonicalizeJson(comparableJwk));
+}
+
+function validateProofJwkUniqueness(proofs: ParsedCredentialProof[]): void {
+  const uniqueKeys = new Set(
+    proofs.map((proof) => createProofJwkUniquenessKey(proof.header.jwk)),
+  );
+
+  if (uniqueKeys.size !== proofs.length) {
+    throw new ValidationError(
+      "Credential request proofs must use unique jwk header values",
+    );
+  }
+}
+
 /**
  * Converts version-specific proof containers (`proof` or `proofs.jwt[]`) into a normalized array.
  */
@@ -271,7 +345,7 @@ function normalizeProofs(options: {
     ];
   }
 
-  return options.credentialRequest.proofs.jwt.map((jwt) =>
+  const proofs = options.credentialRequest.proofs.jwt.map((jwt) =>
     parseProofJwt({
       expected: options.expected,
       grantType: options.grantType,
@@ -279,6 +353,10 @@ function normalizeProofs(options: {
       jwt,
     }),
   );
+
+  validateProofJwkUniqueness(proofs);
+
+  return proofs;
 }
 
 /**

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -4,12 +4,15 @@ import {
   extractDpopJwtFromHeaders,
 } from "@pagopa/io-wallet-oauth2";
 import {
+  type CallbackContext,
   FetchHeaders,
   HEADERS,
+  HashAlgorithm,
   IoWalletSdkConfig,
   ItWalletSpecsVersion,
   ItWalletSpecsVersionError,
   ValidationError,
+  calculateJwkThumbprint,
   createVersionDispatcher,
   parseWithErrorHandling,
 } from "@pagopa/io-wallet-utils";
@@ -72,6 +75,8 @@ export interface ParseCredentialRequestExpectedValues {
  * Input options for parsing a credential request.
  */
 export interface ParseCredentialRequestOptions {
+  /** Callback functions required to calculate proof JWK thumbprints. */
+  callbacks: Pick<CallbackContext, "hash">;
   /** SDK config used to route parsing logic by IT-Wallet specification version. */
   config: IoWalletSdkConfig;
   /** Credential request payload to validate and parse. */
@@ -251,31 +256,43 @@ function parseProofJwt(options: {
   };
 }
 
-function createProofJwkUniquenessKey(jwk: ProofJwtHeader["jwk"]): string {
-  switch (jwk.kty) {
-    case "EC":
-      return JSON.stringify(["EC", jwk.crv, jwk.x, jwk.y]);
-    case "OKP":
-      return JSON.stringify(["OKP", jwk.crv, jwk.x]);
-    case "RSA":
-      return JSON.stringify(["RSA", jwk.e, jwk.n]);
-    case "oct":
-      return JSON.stringify(["oct", jwk.k]);
-    default:
-      return JSON.stringify(
-        Object.entries(jwk).sort(([leftKey], [rightKey]) =>
-          leftKey.localeCompare(rightKey),
-        ),
-      );
+async function calculateProofJwkThumbprint(options: {
+  callbacks: Pick<CallbackContext, "hash">;
+  jwk: ProofJwtHeader["jwk"];
+}): Promise<string> {
+  try {
+    return await calculateJwkThumbprint({
+      hashAlgorithm: HashAlgorithm.Sha256,
+      hashCallback: options.callbacks.hash,
+      jwk: options.jwk,
+    });
+  } catch {
+    throw new ValidationError(
+      "Credential proof JWT jwk header does not match a supported RFC7638 JWK thumbprint structure",
+    );
   }
 }
 
-function validateProofJwkUniqueness(proofs: ParsedCredentialProof[]): void {
-  const uniqueKeys = new Set(
-    proofs.map((proof) => createProofJwkUniquenessKey(proof.header.jwk)),
+async function validateProofJwkUniqueness(options: {
+  callbacks: Pick<CallbackContext, "hash">;
+  proofs: ParsedCredentialProof[];
+}): Promise<void> {
+  if (options.proofs.length <= 1) {
+    return;
+  }
+
+  const thumbprints = await Promise.all(
+    options.proofs.map((proof) =>
+      calculateProofJwkThumbprint({
+        callbacks: options.callbacks,
+        jwk: proof.header.jwk,
+      }),
+    ),
   );
 
-  if (uniqueKeys.size !== proofs.length) {
+  const uniqueThumbprints = new Set(thumbprints);
+
+  if (uniqueThumbprints.size !== thumbprints.length) {
     throw new ValidationError(
       "Credential request proofs must use unique jwk header values",
     );
@@ -285,12 +302,13 @@ function validateProofJwkUniqueness(proofs: ParsedCredentialProof[]): void {
 /**
  * Converts version-specific proof containers (`proof` or `proofs.jwt[]`) into a normalized array.
  */
-function normalizeProofs(options: {
+async function normalizeProofs(options: {
+  callbacks: Pick<CallbackContext, "hash">;
   credentialRequest: CredentialRequestV1_0 | CredentialRequestV1_3;
   expected?: ParseCredentialRequestExpectedValues;
   grantType: GrantType;
   itWalletSpecsVersion: ItWalletSpecsVersion;
-}): ParsedCredentialProof[] {
+}): Promise<ParsedCredentialProof[]> {
   if ("proof" in options.credentialRequest) {
     return [
       parseProofJwt({
@@ -311,7 +329,10 @@ function normalizeProofs(options: {
     }),
   );
 
-  validateProofJwkUniqueness(proofs);
+  await validateProofJwkUniqueness({
+    callbacks: options.callbacks,
+    proofs,
+  });
 
   return proofs;
 }
@@ -319,10 +340,11 @@ function normalizeProofs(options: {
 /**
  * Builds the normalized parse result shared by v1.0 and v1.3 flows.
  */
-function toResult<
+async function toResult<
   TRequest extends CredentialRequestV1_0 | CredentialRequestV1_3,
 >(options: {
   accessToken: string;
+  callbacks: Pick<CallbackContext, "hash">;
   credentialRequest: TRequest;
   dpopProof: string;
   expected?: ParseCredentialRequestExpectedValues;
@@ -332,14 +354,15 @@ function toResult<
     | ItWalletSpecsVersion.V1_0
     | ItWalletSpecsVersion.V1_3
     | ItWalletSpecsVersion.V1_4;
-}): ParsedCredentialRequest {
+}): Promise<ParsedCredentialRequest> {
   validateExpectedValues(options.credentialRequest, options.expected);
   validateTransactionContext({
     credentialRequest: options.credentialRequest,
     isDeferredFlow: options.isDeferredFlow,
   });
 
-  const proofs = normalizeProofs({
+  const proofs = await normalizeProofs({
+    callbacks: options.callbacks,
     credentialRequest: options.credentialRequest,
     expected: options.expected,
     grantType: options.grantType,
@@ -418,7 +441,7 @@ interface ParseCredentialRequestHandlerOptions extends ParseCredentialRequestOpt
 
 function parseCredentialRequestV1_0(
   options: ParseCredentialRequestHandlerOptions,
-): ParsedCredentialRequest {
+): Promise<ParsedCredentialRequest> {
   const credentialRequest = parseWithErrorHandling(
     zCredentialRequestV1_0,
     options.credentialRequest,
@@ -426,6 +449,7 @@ function parseCredentialRequestV1_0(
   );
   return toResult({
     accessToken: options.accessToken,
+    callbacks: options.callbacks,
     credentialRequest,
     dpopProof: options.dpopProof,
     expected: options.expected,
@@ -437,7 +461,7 @@ function parseCredentialRequestV1_0(
 
 function parseCredentialRequestV1_3(
   options: ParseCredentialRequestHandlerOptions,
-): ParsedCredentialRequest {
+): Promise<ParsedCredentialRequest> {
   const credentialRequest = parseWithErrorHandling(
     zCredentialRequestV1_3,
     options.credentialRequest,
@@ -445,6 +469,7 @@ function parseCredentialRequestV1_3(
   );
   return toResult({
     accessToken: options.accessToken,
+    callbacks: options.callbacks,
     credentialRequest,
     dpopProof: options.dpopProof,
     expected: options.expected,
@@ -456,7 +481,7 @@ function parseCredentialRequestV1_3(
 
 function parseCredentialRequestV1_4(
   options: ParseCredentialRequestHandlerOptions,
-): ParsedCredentialRequest {
+): Promise<ParsedCredentialRequest> {
   const credentialRequest = parseWithErrorHandling(
     zCredentialRequestV1_3,
     options.credentialRequest,
@@ -464,6 +489,7 @@ function parseCredentialRequestV1_4(
   );
   return toResult({
     accessToken: options.accessToken,
+    callbacks: options.callbacks,
     credentialRequest,
     dpopProof: options.dpopProof,
     expected: options.expected,
@@ -475,7 +501,7 @@ function parseCredentialRequestV1_4(
 
 const dispatchParseCredentialRequest = createVersionDispatcher<
   ParseCredentialRequestHandlerOptions,
-  ParsedCredentialRequest
+  Promise<ParsedCredentialRequest>
 >({
   [ItWalletSpecsVersion.V1_0]: parseCredentialRequestV1_0,
   [ItWalletSpecsVersion.V1_3]: parseCredentialRequestV1_3,
@@ -499,23 +525,24 @@ const dispatchParseCredentialRequest = createVersionDispatcher<
  *    for deferred vs. immediate issuance flows.
  * 6. **Proof JWT structure** — decodes each proof JWT and validates its header and
  *    payload claims, including `iss` requirements for the `authorization_code` grant.
- *    For v1.3, asserts the `key_attestation` header claim is present and non-empty.
+ *    For v1.3, asserts the `key_attestation` header claim is present and non-empty,
+ *    and validates batch proof key uniqueness with RFC7638 JWK thumbprints.
  *
  * This function does not perform cryptographic signature verification on proof JWTs
  * or the DPoP proof. Both must be verified separately after parsing.
  * For DPoP proofs, the caller can use the `verifyTokenDPoP` function exported by io-wallet-oauth2.
  *
  * @param options - Parsing options and validation context.
- * @returns Normalized parsed credential request including the extracted `accessToken` and `dpopProof`.
+ * @returns Promise resolving to the normalized parsed credential request including the extracted `accessToken` and `dpopProof`.
  * @throws {CredentialAuthorizationHeaderError} If the `Authorization` header is absent or invalid.
  * @throws {CredentialDpopProofError} If the `DPoP` header is absent or not a valid compact JWT.
  * @throws {ValidationError} If request body schema or semantic checks fail.
  * @throws {Oauth2JwtParseError} If a proof JWT cannot be decoded.
  * @throws {ParseCredentialRequestError} For unexpected parsing failures.
  */
-export function parseCredentialRequest(
+export async function parseCredentialRequest(
   options: ParseCredentialRequestOptions,
-): ParsedCredentialRequest {
+): Promise<ParsedCredentialRequest> {
   const grantType = options.grantType ?? "authorization_code";
   const isDeferredFlow = options.isDeferredFlow ?? false;
 
@@ -523,7 +550,7 @@ export function parseCredentialRequest(
     const accessToken = parseAuthorizationHeader(options.headers);
     const dpopProof = parseDpopProof(options.headers);
 
-    return dispatchParseCredentialRequest({
+    return await dispatchParseCredentialRequest({
       ...options,
       accessToken,
       dpopProof,

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -251,66 +251,23 @@ function parseProofJwt(options: {
   };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function canonicalizeJson(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(canonicalizeJson);
-  }
-
-  if (!isRecord(value)) {
-    return value;
-  }
-
-  return Object.keys(value)
-    .sort()
-    .reduce<Record<string, unknown>>((acc, key) => {
-      const property = value[key];
-      if (property !== undefined) {
-        acc[key] = canonicalizeJson(property);
-      }
-      return acc;
-    }, {});
-}
-
-function pickJwkMembers(
-  jwk: Record<string, unknown>,
-  members: string[],
-): Record<string, unknown> | undefined {
-  if (members.some((member) => jwk[member] === undefined)) {
-    return undefined;
-  }
-
-  return members.reduce<Record<string, unknown>>((acc, member) => {
-    acc[member] = jwk[member];
-    return acc;
-  }, {});
-}
-
-function getJwkThumbprintInput(
-  jwk: Record<string, unknown>,
-): Record<string, unknown> | undefined {
+function createProofJwkUniquenessKey(jwk: ProofJwtHeader["jwk"]): string {
   switch (jwk.kty) {
     case "EC":
-      return pickJwkMembers(jwk, ["crv", "kty", "x", "y"]);
+      return JSON.stringify(["EC", jwk.crv, jwk.x, jwk.y]);
     case "OKP":
-      return pickJwkMembers(jwk, ["crv", "kty", "x"]);
+      return JSON.stringify(["OKP", jwk.crv, jwk.x]);
     case "RSA":
-      return pickJwkMembers(jwk, ["e", "kty", "n"]);
+      return JSON.stringify(["RSA", jwk.e, jwk.n]);
     case "oct":
-      return pickJwkMembers(jwk, ["k", "kty"]);
+      return JSON.stringify(["oct", jwk.k]);
     default:
-      return undefined;
+      return JSON.stringify(
+        Object.entries(jwk).sort(([leftKey], [rightKey]) =>
+          leftKey.localeCompare(rightKey),
+        ),
+      );
   }
-}
-
-function createProofJwkUniquenessKey(jwk: unknown): string {
-  const comparableJwk = isRecord(jwk)
-    ? (getJwkThumbprintInput(jwk) ?? jwk)
-    : jwk;
-  return JSON.stringify(canonicalizeJson(comparableJwk));
 }
 
 function validateProofJwkUniqueness(proofs: ParsedCredentialProof[]): void {

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -322,7 +322,7 @@ async function normalizeProofs(options: {
 }
 
 /**
- * Builds the normalized parse result shared by v1.0 and v1.3 flows.
+ * Builds the normalized parse result shared by v1.0, v1.3 and v1.4 flows.
  */
 async function toResult<
   TRequest extends CredentialRequestV1_0 | CredentialRequestV1_3,
@@ -509,9 +509,9 @@ const dispatchParseCredentialRequest = createVersionDispatcher<
  *    for deferred vs. immediate issuance flows.
  * 6. **Proof JWT structure** — decodes each proof JWT and validates its header and
  *    payload claims, including `iss` requirements for the `authorization_code` grant.
- *    For v1.3, asserts the `key_attestation` header claim is present and non-empty,
- *    and validates batch proof key uniqueness with RFC7638 JWK thumbprints.
- *
+ *    For v1.3, asserts the `key_attestation` header claim is present and non-empty.
+ *    For requests using `proofs.jwt` (including v1.3 and v1.4), validates batch
+ *    proof key uniqueness with RFC7638 JWK thumbprints.
  * This function does not perform cryptographic signature verification on proof JWTs
  * or the DPoP proof. Both must be verified separately after parsing.
  * For DPoP proofs, the caller can use the `verifyTokenDPoP` function exported by io-wallet-oauth2.


### PR DESCRIPTION
This PR adds batch proof JWK uniqueness validation to credential request parsing.

For credential requests using `proofs.jwt`, the parser now calculates RFC7638 JWK thumbprints with SHA-256 and rejects requests where multiple proofs use the same `jwk` header value. This prevents duplicate proof keys from being accepted in batch credential requests.

## Changes

* Added a required `callbacks.hash` option to `parseCredentialRequest`.
* Made `parseCredentialRequest` and version-specific handlers asynchronous.
* Added `validateProofJwkUniqueness` to:

  * calculate JWK thumbprints for each proof JWT header JWK,
  * compare thumbprints for duplicates,
  * throw `ValidationError` when duplicate proof keys are found.
* Updated proof normalization so uniqueness validation runs for `proofs.jwt[]` requests.
* Updated documentation to mention batch proof key uniqueness validation for v1.3 and v1.4 flows.

## Notes

Single-proof requests using `proof` are unchanged. The new validation only applies when parsing multiple proofs from `proofs.jwt[]`.

## Breaking change

`parseCredentialRequest` now returns a `Promise<ParsedCredentialRequest>` and requires `callbacks.hash`, so callers must `await` the function and provide a hash callback.
