### PR TITLE
perf: Refine credential offer related functionalities

### DIFF
--- a/.changeset/two-ties-find.md
+++ b/.changeset/two-ties-find.md
@@ -1,0 +1,11 @@
+---
+"@pagopa/io-wallet-oid4vci": minor
+"@pagopa/io-wallet-oauth2": minor
+---
+
+Refined credential offer related functionalities by:
+
+- adding the issuerState optional field in create-authorization-request in the oauth2 package.
+- adding checks of the offer's authorization_server field.
+- adding support for ITW v1.4 offer,
+- adding the authorization_server field to fetch the metadata from the issuer-suggested server in case of a credential offer flow.

--- a/.changeset/two-ties-find.md
+++ b/.changeset/two-ties-find.md
@@ -9,3 +9,4 @@ Refined credential offer related functionalities by:
 - adding checks of the offer's authorization_server field.
 - adding support for ITW v1.4 offer,
 - adding the authorization_server field to fetch the metadata from the issuer-suggested server in case of a credential offer flow.
+- improving the `fetchMetadata` federation path by making it fetch another OID-FED EC in case the `openid-credential-issuer.authorization_servers` is present and doesn't specify the issuer itself.

--- a/packages/oauth2/src/authorization-request/create-authorization-request.ts
+++ b/packages/oauth2/src/authorization-request/create-authorization-request.ts
@@ -85,6 +85,12 @@ interface BaseCreatePushedAuthorizationRequestOptions<
   issuedAt?: Date;
 
   /**
+   * Optional issuer state from the Credential Offer authorization_code grant.
+   * Serialized as issuer_state in the authorization request.
+   */
+  issuerState?: string;
+
+  /**
    * jti parameter to use for PAR. If not provided a value will generated automatically
    */
   jti?: string;
@@ -300,6 +306,9 @@ export async function createPushedAuthorizationRequest(
     client_id: options.clientId,
     code_challenge: pkce.codeChallenge,
     code_challenge_method: pkce.codeChallengeMethod,
+    ...(options.issuerState !== undefined
+      ? { issuer_state: options.issuerState }
+      : {}),
     jti:
       options.jti ??
       encodeToBase64Url(

--- a/packages/oid-federation/src/metadata/entity/v1.0/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.0/itWalletCredentialIssuer.ts
@@ -46,7 +46,7 @@ export const SupportedCredentialMetadata = z.intersection(
 );
 
 export const itWalletCredentialIssuerMetadata = z.looseObject({
-  authorization_servers: z.array(z.url()).optional(),
+  authorization_servers: z.tuple([z.url()], z.url()).optional(),
   batch_credential_issuance: z.object({
     batch_size: z.number().int(),
   }),

--- a/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.3/itWalletCredentialIssuer.ts
@@ -146,7 +146,7 @@ export const SupportedCredentialMetadata = z.intersection(
  * {@link https://italia.github.io/eid-wallet-it-docs/releases/1.3.0/en/credential-issuer-solution.html#metadata-for-openid-credential-issuer}
  */
 export const itWalletCredentialIssuerMetadata = z.looseObject({
-  authorization_servers: z.array(z.url()).optional(),
+  authorization_servers: z.tuple([z.url()], z.url()).optional(),
   batch_credential_issuance: z
     .object({
       batch_size: z.number().int().positive(),

--- a/packages/oid4vci/src/credential-offer/__tests__/extract-grant-details.test.ts
+++ b/packages/oid4vci/src/credential-offer/__tests__/extract-grant-details.test.ts
@@ -1,10 +1,25 @@
 /* eslint-disable max-lines-per-function */
+import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+} from "@pagopa/io-wallet-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { CredentialOffer } from "../z-credential-offer";
+import type {
+  CredentialOfferV1_3,
+  CredentialOfferV1_4,
+} from "../z-credential-offer";
 
 import { CredentialOfferError } from "../../errors";
 import { extractGrantDetails } from "../extract-grant-details";
+
+const v1_3Config = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
+});
+
+const v1_4Config = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_4,
+});
 
 describe("extractGrantDetails", () => {
   beforeEach(() => {
@@ -13,7 +28,7 @@ describe("extractGrantDetails", () => {
 
   describe("successful extraction", () => {
     it("should extract authorization_code grant with only required fields", () => {
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -23,7 +38,10 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       expect(result.grantType).toBe("authorization_code");
       expect(result.authorizationCodeGrant.scope).toBe("openid");
@@ -32,7 +50,7 @@ describe("extractGrantDetails", () => {
     });
 
     it("should extract authorization_code grant with all fields", () => {
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -44,7 +62,10 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       expect(result.grantType).toBe("authorization_code");
       expect(result.authorizationCodeGrant.scope).toBe("openid profile");
@@ -57,7 +78,7 @@ describe("extractGrantDetails", () => {
     });
 
     it("should extract authorization_code grant with authorization_server only", () => {
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -68,7 +89,10 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       expect(result.grantType).toBe("authorization_code");
       expect(result.authorizationCodeGrant.scope).toBe("openid");
@@ -79,7 +103,7 @@ describe("extractGrantDetails", () => {
     });
 
     it("should extract authorization_code grant with issuer_state only", () => {
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -90,7 +114,10 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       expect(result.grantType).toBe("authorization_code");
       expect(result.authorizationCodeGrant.scope).toBe("openid");
@@ -101,65 +128,73 @@ describe("extractGrantDetails", () => {
 
   describe("error cases", () => {
     it("should throw CredentialOfferError when grants is missing", () => {
-      const offer = {
+      const credentialOffer = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         // grants is missing
-      } as unknown as CredentialOffer;
+      } as unknown as CredentialOfferV1_3;
 
-      expect(() => extractGrantDetails(offer)).toThrow(CredentialOfferError);
-      expect(() => extractGrantDetails(offer)).toThrow(
-        "No grants found in credential offer",
-      );
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow(CredentialOfferError);
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow("No grants found in credential offer");
     });
 
     it("should throw CredentialOfferError when authorization_code grant is missing", () => {
-      const offer = {
+      const credentialOffer = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
           // authorization_code is missing
         },
-      } as unknown as CredentialOffer;
+      } as unknown as CredentialOfferV1_3;
 
-      expect(() => extractGrantDetails(offer)).toThrow(CredentialOfferError);
-      expect(() => extractGrantDetails(offer)).toThrow(
-        "authorization_code grant not found",
-      );
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow(CredentialOfferError);
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow("authorization_code grant not found");
     });
 
     it("should throw CredentialOfferError when grants is null", () => {
-      const offer = {
+      const credentialOffer = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: null,
-      } as unknown as CredentialOffer;
+      } as unknown as CredentialOfferV1_3;
 
-      expect(() => extractGrantDetails(offer)).toThrow(CredentialOfferError);
-      expect(() => extractGrantDetails(offer)).toThrow(
-        "No grants found in credential offer",
-      );
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow(CredentialOfferError);
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow("No grants found in credential offer");
     });
 
     it("should throw CredentialOfferError when authorization_code is null", () => {
-      const offer = {
+      const credentialOffer = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
           authorization_code: null,
         },
-      } as unknown as CredentialOffer;
+      } as unknown as CredentialOfferV1_3;
 
-      expect(() => extractGrantDetails(offer)).toThrow(CredentialOfferError);
-      expect(() => extractGrantDetails(offer)).toThrow(
-        "authorization_code grant not found",
-      );
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow(CredentialOfferError);
+      expect(() =>
+        extractGrantDetails({ config: v1_3Config, credentialOffer }),
+      ).toThrow("authorization_code grant not found");
     });
   });
 
   describe("edge cases", () => {
-    it("should always return authorization_code as grantType for IT-Wallet v1.3", () => {
-      const offer: CredentialOffer = {
+    it("should always return authorization_code as grantType for IT-Wallet", () => {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -169,14 +204,17 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
-      // IT-Wallet v1.3 only supports authorization_code grant
+      // IT-Wallet only supports authorization_code grant
       expect(result.grantType).toBe("authorization_code");
     });
 
     it("should handle complex scope values", () => {
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -186,7 +224,10 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       expect(result.authorizationCodeGrant.scope).toBe(
         "openid profile email address phone offline_access",
@@ -195,7 +236,7 @@ describe("extractGrantDetails", () => {
 
     it("should handle long issuer_state values", () => {
       const longIssuerState = "a".repeat(500);
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -206,14 +247,17 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       expect(result.authorizationCodeGrant.issuerState).toBe(longIssuerState);
       expect(result.authorizationCodeGrant.issuerState).toHaveLength(500);
     });
 
     it("should handle multiple credential_configuration_ids without affecting grant extraction", () => {
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: [
           "UniversityDegree",
           "EmployeeID",
@@ -227,7 +271,10 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       expect(result.grantType).toBe("authorization_code");
       expect(result.authorizationCodeGrant.scope).toBe("openid");
@@ -236,7 +283,7 @@ describe("extractGrantDetails", () => {
 
   describe("type correctness", () => {
     it("should return ExtractGrantDetailsResult with correct structure", () => {
-      const offer: CredentialOffer = {
+      const credentialOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -248,7 +295,10 @@ describe("extractGrantDetails", () => {
         },
       };
 
-      const result = extractGrantDetails(offer);
+      const result = extractGrantDetails({
+        config: v1_3Config,
+        credentialOffer,
+      });
 
       // Check result structure
       expect(result).toHaveProperty("grantType");
@@ -268,6 +318,45 @@ describe("extractGrantDetails", () => {
         "string",
       );
       expect(typeof result.authorizationCodeGrant.issuerState).toBe("string");
+    });
+  });
+
+  describe("v1.4", () => {
+    it("should extract grant details without scope for a v1.4 offer", () => {
+      const credentialOffer: CredentialOfferV1_4 = {
+        credential_configuration_ids: ["UniversityDegree"],
+        credential_issuer: "https://issuer.example.com",
+        grants: {
+          authorization_code: {
+            authorization_server: "https://auth.issuer.example.com",
+            issuer_state: "state-value-123",
+          },
+        },
+      };
+
+      const result = extractGrantDetails({
+        config: v1_4Config,
+        credentialOffer,
+      });
+
+      expect(result.grantType).toBe("authorization_code");
+      expect(result.authorizationCodeGrant.authorizationServer).toBe(
+        "https://auth.issuer.example.com",
+      );
+      expect(result.authorizationCodeGrant.issuerState).toBe("state-value-123");
+      expect("scope" in result.authorizationCodeGrant).toBe(false);
+    });
+
+    it("should throw CredentialOfferError when authorization_code grant is missing for a v1.4 offer", () => {
+      const credentialOffer = {
+        credential_configuration_ids: ["UniversityDegree"],
+        credential_issuer: "https://issuer.example.com",
+        grants: {},
+      } as unknown as CredentialOfferV1_4;
+
+      expect(() =>
+        extractGrantDetails({ config: v1_4Config, credentialOffer }),
+      ).toThrow("authorization_code grant not found");
     });
   });
 });

--- a/packages/oid4vci/src/credential-offer/__tests__/resolve-credential-offer.test.ts
+++ b/packages/oid4vci/src/credential-offer/__tests__/resolve-credential-offer.test.ts
@@ -1,8 +1,15 @@
 /* eslint-disable max-lines-per-function */
-import { UnexpectedStatusCodeError } from "@pagopa/io-wallet-utils";
+import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+  UnexpectedStatusCodeError,
+} from "@pagopa/io-wallet-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { CredentialOffer } from "../z-credential-offer";
+import type {
+  CredentialOfferV1_3,
+  CredentialOfferV1_4,
+} from "../z-credential-offer";
 
 import { CredentialOfferError } from "../../errors";
 import { resolveCredentialOffer } from "../resolve-credential-offer";
@@ -18,7 +25,7 @@ vi.mock("@openid4vc/utils", async (importOriginal) => {
 });
 
 describe("resolveCredentialOffer", () => {
-  const validCredentialOffer: CredentialOffer = {
+  const validCredentialOffer: CredentialOfferV1_3 = {
     credential_configuration_ids: ["UniversityDegree"],
     credential_issuer: "https://issuer.example.com",
     grants: {
@@ -32,6 +39,9 @@ describe("resolveCredentialOffer", () => {
     callbacks: {
       fetch: mockFetch,
     },
+    config: new IoWalletSdkConfig({
+      itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
+    }),
   };
 
   beforeEach(() => {
@@ -351,7 +361,7 @@ describe("resolveCredentialOffer", () => {
 
   describe("edge cases", () => {
     it("should handle credential offer with all optional fields", async () => {
-      const fullOffer: CredentialOffer = {
+      const fullOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree", "EmployeeID"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -381,7 +391,7 @@ describe("resolveCredentialOffer", () => {
     });
 
     it("should handle credential offer with multiple credential_configuration_ids", async () => {
-      const multiConfigOffer: CredentialOffer = {
+      const multiConfigOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: [
           "UniversityDegree",
           "EmployeeID",
@@ -403,6 +413,79 @@ describe("resolveCredentialOffer", () => {
       });
 
       expect(result.credential_configuration_ids).toHaveLength(3);
+    });
+  });
+
+  describe("v1.4", () => {
+    const v1_4Options = {
+      callbacks: {
+        fetch: mockFetch,
+      },
+      config: new IoWalletSdkConfig({
+        itWalletSpecsVersion: ItWalletSpecsVersion.V1_4,
+      }),
+    };
+
+    const validV1_4Offer: CredentialOfferV1_4 = {
+      credential_configuration_ids: ["UniversityDegree"],
+      credential_issuer: "https://issuer.example.com",
+      grants: {
+        authorization_code: {
+          issuer_state: "eyJhbGciOiJSU0Et...zaEJ3w",
+        },
+      },
+    };
+
+    it("should resolve a v1.4 offer without scope", async () => {
+      const jsonString = JSON.stringify(validV1_4Offer);
+
+      const result = await resolveCredentialOffer({
+        credentialOffer: jsonString,
+        ...v1_4Options,
+      });
+
+      expect(result).toEqual(validV1_4Offer);
+      expect(result.grants.authorization_code.issuer_state).toBe(
+        "eyJhbGciOiJSU0Et...zaEJ3w",
+      );
+      expect("scope" in result.grants.authorization_code).toBe(false);
+    });
+
+    it("should drop a stray scope from a v1.4 offer", async () => {
+      const offerWithScope = {
+        ...validV1_4Offer,
+        grants: {
+          authorization_code: {
+            issuer_state: "eyJhbGciOiJSU0Et...zaEJ3w",
+            scope: "openid",
+          },
+        },
+      };
+      const jsonString = JSON.stringify(offerWithScope);
+
+      const result = await resolveCredentialOffer({
+        credentialOffer: jsonString,
+        ...v1_4Options,
+      });
+
+      expect("scope" in result.grants.authorization_code).toBe(false);
+    });
+
+    it("should still require credential_issuer for a v1.4 offer", async () => {
+      const invalidOffer = {
+        credential_configuration_ids: ["UniversityDegree"],
+        grants: {
+          authorization_code: {},
+        },
+      };
+      const jsonString = JSON.stringify(invalidOffer);
+
+      await expect(
+        resolveCredentialOffer({
+          credentialOffer: jsonString,
+          ...v1_4Options,
+        }),
+      ).rejects.toThrow(CredentialOfferError);
     });
   });
 });

--- a/packages/oid4vci/src/credential-offer/__tests__/validate-credential-offer.test.ts
+++ b/packages/oid4vci/src/credential-offer/__tests__/validate-credential-offer.test.ts
@@ -65,6 +65,12 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {
+          authorization_servers: [
+            "https://auth.issuer.example.com",
+            "https://auth2.issuer.example.com",
+          ],
+        },
         credentialOffer: fullOffer,
       };
 
@@ -210,7 +216,7 @@ describe("validateCredentialOffer", () => {
   });
 
   describe("authorization_server conditional validation", () => {
-    it("should validate when authorization_server is present with single auth server in metadata", async () => {
+    it("should throw CredentialOfferError when authorization_server is present with a single-entry auth servers list", async () => {
       const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
@@ -229,7 +235,13 @@ describe("validateCredentialOffer", () => {
         credentialOffer: offer,
       };
 
-      await expect(validateCredentialOffer(options)).resolves.toBeUndefined();
+      await expect(validateCredentialOffer(options)).rejects.toThrow(
+        CredentialOfferError,
+      );
+
+      await expect(validateCredentialOffer(options)).rejects.toThrow(
+        "credential offer specified an `authorization_server` but issuer metadata's `authorization_servers` contains only an element",
+      );
     });
 
     it("should throw CredentialOfferError when authorization_server is missing with multiple auth servers", async () => {
@@ -341,7 +353,7 @@ describe("validateCredentialOffer", () => {
       await expect(validateCredentialOffer(options)).resolves.toBeUndefined();
     });
 
-    it("should validate when no credentialIssuerMetadata is provided", async () => {
+    it("should throw CredentialOfferError when authorization_server is present but no credentialIssuerMetadata is provided", async () => {
       const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
@@ -358,7 +370,13 @@ describe("validateCredentialOffer", () => {
         // No credentialIssuerMetadata provided
       };
 
-      await expect(validateCredentialOffer(options)).resolves.toBeUndefined();
+      await expect(validateCredentialOffer(options)).rejects.toThrow(
+        CredentialOfferError,
+      );
+
+      await expect(validateCredentialOffer(options)).rejects.toThrow(
+        "credential offer specified an `authorization_server` but issuer metadata doesn't contain `authorization_servers`",
+      );
     });
 
     it("should validate when credentialIssuerMetadata has no authorization_servers", async () => {

--- a/packages/oid4vci/src/credential-offer/__tests__/validate-credential-offer.test.ts
+++ b/packages/oid4vci/src/credential-offer/__tests__/validate-credential-offer.test.ts
@@ -1,14 +1,32 @@
 /* eslint-disable max-lines-per-function */
+import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+} from "@pagopa/io-wallet-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import type { ValidateCredentialOfferOptions } from "../types";
-import type { CredentialOffer } from "../z-credential-offer";
+import type {
+  ValidateCredentialOfferOptionsV1_3,
+  ValidateCredentialOfferOptionsV1_4,
+} from "../types";
+import type {
+  CredentialOfferV1_3,
+  CredentialOfferV1_4,
+} from "../z-credential-offer";
 
 import { CredentialOfferError } from "../../errors";
 import { validateCredentialOffer } from "../validate-credential-offer";
 
+const v1_3Config = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
+});
+
+const v1_4Config = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_4,
+});
+
 describe("validateCredentialOffer", () => {
-  const validCredentialOffer: CredentialOffer = {
+  const validCredentialOffer: CredentialOfferV1_3 = {
     credential_configuration_ids: ["UniversityDegree"],
     credential_issuer: "https://issuer.example.com",
     grants: {
@@ -24,7 +42,8 @@ describe("validateCredentialOffer", () => {
 
   describe("successful validation", () => {
     it("should validate a valid credential offer", async () => {
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: validCredentialOffer,
       };
 
@@ -32,7 +51,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should validate credential offer with all optional fields", async () => {
-      const fullOffer: CredentialOffer = {
+      const fullOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree", "EmployeeID"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -44,7 +63,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: fullOffer,
       };
 
@@ -52,7 +72,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should validate credential offer with multiple credential_configuration_ids", async () => {
-      const multiConfigOffer: CredentialOffer = {
+      const multiConfigOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: [
           "UniversityDegree",
           "EmployeeID",
@@ -66,7 +86,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: multiConfigOffer,
       };
 
@@ -76,12 +97,13 @@ describe("validateCredentialOffer", () => {
 
   describe("credential_issuer validation", () => {
     it("should throw CredentialOfferError when credential_issuer is not HTTPS", async () => {
-      const invalidOffer: CredentialOffer = {
+      const invalidOffer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         credential_issuer: "http://issuer.example.com",
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: invalidOffer,
       };
 
@@ -97,12 +119,13 @@ describe("validateCredentialOffer", () => {
 
   describe("credential_configuration_ids validation", () => {
     it("should throw CredentialOfferError when credential_configuration_ids is empty", async () => {
-      const invalidOffer: CredentialOffer = {
+      const invalidOffer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         credential_configuration_ids: [],
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: invalidOffer,
       };
 
@@ -121,9 +144,10 @@ describe("validateCredentialOffer", () => {
       const invalidOffer = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
-      } as unknown as CredentialOffer;
+      } as unknown as CredentialOfferV1_3;
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: invalidOffer,
       };
 
@@ -141,9 +165,10 @@ describe("validateCredentialOffer", () => {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {},
-      } as unknown as CredentialOffer;
+      } as unknown as CredentialOfferV1_3;
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: invalidOffer,
       };
 
@@ -159,7 +184,7 @@ describe("validateCredentialOffer", () => {
 
   describe("scope validation", () => {
     it("should throw CredentialOfferError when scope is missing", async () => {
-      const invalidOffer: CredentialOffer = {
+      const invalidOffer: CredentialOfferV1_3 = {
         credential_configuration_ids: ["UniversityDegree"],
         credential_issuer: "https://issuer.example.com",
         grants: {
@@ -169,7 +194,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: invalidOffer,
       };
 
@@ -185,7 +211,7 @@ describe("validateCredentialOffer", () => {
 
   describe("authorization_server conditional validation", () => {
     it("should validate when authorization_server is present with single auth server in metadata", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -195,7 +221,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialIssuerMetadata: {
           authorization_servers: ["https://auth.issuer.example.com"],
         },
@@ -206,7 +233,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should throw CredentialOfferError when authorization_server is missing with multiple auth servers", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -216,7 +243,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialIssuerMetadata: {
           authorization_servers: [
             "https://auth1.issuer.example.com",
@@ -236,7 +264,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should validate when authorization_server is present and matches one of multiple auth servers", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -246,7 +274,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialIssuerMetadata: {
           authorization_servers: [
             "https://auth1.issuer.example.com",
@@ -260,7 +289,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should throw CredentialOfferError when authorization_server does not match metadata", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -270,7 +299,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialIssuerMetadata: {
           authorization_servers: [
             "https://auth1.issuer.example.com",
@@ -290,7 +320,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should validate when authorization_server is optional with single auth server", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -300,7 +330,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialIssuerMetadata: {
           authorization_servers: ["https://auth.issuer.example.com"],
         },
@@ -311,7 +342,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should validate when no credentialIssuerMetadata is provided", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -321,7 +352,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: offer,
         // No credentialIssuerMetadata provided
       };
@@ -330,7 +362,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should validate when credentialIssuerMetadata has no authorization_servers", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -339,7 +371,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialIssuerMetadata: {
           // No authorization_servers field
         },
@@ -352,7 +385,7 @@ describe("validateCredentialOffer", () => {
 
   describe("edge cases", () => {
     it("should validate credential offer with issuer_state", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -362,7 +395,8 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: offer,
       };
 
@@ -370,7 +404,7 @@ describe("validateCredentialOffer", () => {
     });
 
     it("should validate credential offer with complex scope", async () => {
-      const offer: CredentialOffer = {
+      const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
           authorization_code: {
@@ -379,11 +413,100 @@ describe("validateCredentialOffer", () => {
         },
       };
 
-      const options: ValidateCredentialOfferOptions = {
+      const options: ValidateCredentialOfferOptionsV1_3 = {
+        config: v1_3Config,
         credentialOffer: offer,
       };
 
       await expect(validateCredentialOffer(options)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("v1.4", () => {
+    const validV1_4Offer: CredentialOfferV1_4 = {
+      credential_configuration_ids: ["UniversityDegree"],
+      credential_issuer: "https://issuer.example.com",
+      grants: {
+        authorization_code: {
+          issuer_state: "eyJhbGciOiJSU0Et...zaEJ3w",
+        },
+      },
+    };
+
+    it("should validate a v1.4 offer that carries no scope", async () => {
+      const options: ValidateCredentialOfferOptionsV1_4 = {
+        config: v1_4Config,
+        credentialOffer: validV1_4Offer,
+      };
+
+      await expect(validateCredentialOffer(options)).resolves.toBeUndefined();
+    });
+
+    it("should validate a v1.4 offer with only the required fields", async () => {
+      const options: ValidateCredentialOfferOptionsV1_4 = {
+        config: v1_4Config,
+        credentialOffer: {
+          credential_configuration_ids: ["UniversityDegree"],
+          credential_issuer: "https://issuer.example.com",
+          grants: {
+            authorization_code: {},
+          },
+        },
+      };
+
+      await expect(validateCredentialOffer(options)).resolves.toBeUndefined();
+    });
+
+    it("should still enforce HTTPS credential_issuer for a v1.4 offer", async () => {
+      const options: ValidateCredentialOfferOptionsV1_4 = {
+        config: v1_4Config,
+        credentialOffer: {
+          ...validV1_4Offer,
+          credential_issuer: "http://issuer.example.com",
+        },
+      };
+
+      await expect(validateCredentialOffer(options)).rejects.toThrow(
+        "credential_issuer must be an HTTPS URL",
+      );
+    });
+
+    it("should report the v1.4 version label when grants is missing", async () => {
+      const options: ValidateCredentialOfferOptionsV1_4 = {
+        config: v1_4Config,
+        credentialOffer: {
+          credential_configuration_ids: ["UniversityDegree"],
+          credential_issuer: "https://issuer.example.com",
+        } as unknown as CredentialOfferV1_4,
+      };
+
+      await expect(validateCredentialOffer(options)).rejects.toThrow(
+        "grants is REQUIRED for IT-Wallet v1.4",
+      );
+    });
+
+    it("should still enforce the authorization_server match for a v1.4 offer", async () => {
+      const options: ValidateCredentialOfferOptionsV1_4 = {
+        config: v1_4Config,
+        credentialIssuerMetadata: {
+          authorization_servers: [
+            "https://auth1.issuer.example.com",
+            "https://auth2.issuer.example.com",
+          ],
+        },
+        credentialOffer: {
+          ...validV1_4Offer,
+          grants: {
+            authorization_code: {
+              authorization_server: "https://unknown-auth.example.com",
+            },
+          },
+        },
+      };
+
+      await expect(validateCredentialOffer(options)).rejects.toThrow(
+        "authorization_server 'https://unknown-auth.example.com' does not match Credential Issuer metadata",
+      );
     });
   });
 });

--- a/packages/oid4vci/src/credential-offer/extract-grant-details.ts
+++ b/packages/oid4vci/src/credential-offer/extract-grant-details.ts
@@ -1,27 +1,32 @@
-import type { ExtractGrantDetailsResult } from "./types";
-import type { CredentialOffer } from "./z-credential-offer";
+import {
+  ItWalletSpecsVersion,
+  ItWalletSpecsVersionError,
+  createVersionDispatcher,
+} from "@pagopa/io-wallet-utils";
+
+import type {
+  ExtractGrantDetailsOptions,
+  ExtractGrantDetailsOptionsV1_3,
+  ExtractGrantDetailsOptionsV1_4,
+  ExtractGrantDetailsResult,
+  ExtractGrantDetailsResultV1_3,
+  ExtractGrantDetailsResultV1_4,
+} from "./types";
+import type {
+  AuthorizationCodeGrantV1_3,
+  AuthorizationCodeGrantV1_4,
+} from "./z-credential-offer";
 
 import { CredentialOfferError } from "../errors";
 
 /**
- * Extracts grant details from a credential offer.
+ * Resolves the authorization_code grant from a credential offer, enforcing its presence.
  *
- * IT-Wallet v1.3 only supports the `authorization_code` grant type.
- * Pre-authorized code grants are NOT supported.
- *
- * This function extracts:
- * - Grant type (always "authorization_code" for IT-Wallet)
- * - Scope (REQUIRED)
- * - Authorization server (OPTIONAL, but REQUIRED when CI uses multiple auth servers)
- * - Issuer state (OPTIONAL)
- *
- * @param credentialOffer - The credential offer to extract grant details from
- * @returns Grant details containing the grant type and authorization code grant information
- * @throws {CredentialOfferError} If grants or authorization_code grant is missing
+ * @throws {CredentialOfferError} If grants or the authorization_code grant is missing.
  */
-export function extractGrantDetails(
-  credentialOffer: CredentialOffer,
-): ExtractGrantDetailsResult {
+function requireAuthorizationCodeGrant<
+  TGrant extends AuthorizationCodeGrantV1_3 | AuthorizationCodeGrantV1_4,
+>(credentialOffer: { grants?: { authorization_code?: TGrant } }): TGrant {
   if (!credentialOffer.grants) {
     throw new CredentialOfferError("No grants found in credential offer");
   }
@@ -32,6 +37,14 @@ export function extractGrantDetails(
     throw new CredentialOfferError("authorization_code grant not found");
   }
 
+  return authCodeGrant;
+}
+
+function extractGrantDetailsV1_3(
+  options: ExtractGrantDetailsOptionsV1_3,
+): ExtractGrantDetailsResultV1_3 {
+  const authCodeGrant = requireAuthorizationCodeGrant(options.credentialOffer);
+
   return {
     authorizationCodeGrant: {
       authorizationServer: authCodeGrant.authorization_server,
@@ -40,4 +53,66 @@ export function extractGrantDetails(
     },
     grantType: "authorization_code",
   };
+}
+
+function extractGrantDetailsV1_4(
+  options: ExtractGrantDetailsOptionsV1_4,
+): ExtractGrantDetailsResultV1_4 {
+  const authCodeGrant = requireAuthorizationCodeGrant(options.credentialOffer);
+
+  return {
+    authorizationCodeGrant: {
+      authorizationServer: authCodeGrant.authorization_server,
+      issuerState: authCodeGrant.issuer_state,
+    },
+    grantType: "authorization_code",
+  };
+}
+
+const dispatchExtractGrantDetails = createVersionDispatcher<
+  ExtractGrantDetailsOptions,
+  ExtractGrantDetailsResult
+>({
+  [ItWalletSpecsVersion.V1_0]: () => {
+    throw new ItWalletSpecsVersionError(
+      "extractGrantDetails",
+      ItWalletSpecsVersion.V1_0,
+      [ItWalletSpecsVersion.V1_3, ItWalletSpecsVersion.V1_4],
+    );
+  },
+  [ItWalletSpecsVersion.V1_3]: (o) =>
+    extractGrantDetailsV1_3(o as ExtractGrantDetailsOptionsV1_3),
+  [ItWalletSpecsVersion.V1_4]: (o) =>
+    extractGrantDetailsV1_4(o as ExtractGrantDetailsOptionsV1_4),
+});
+
+/**
+ * Extracts grant details from a credential offer according to the configured
+ * Italian Wallet specification version.
+ *
+ * IT-Wallet only supports the `authorization_code` grant type. Pre-authorized
+ * code grants are NOT supported.
+ *
+ * Version Differences:
+ * - v1.3: extracts `scope` (REQUIRED), `authorization_server` (OPTIONAL), `issuer_state` (OPTIONAL)
+ * - v1.4: extracts `authorization_server` (OPTIONAL) and `issuer_state` (OPTIONAL); the
+ *   credential offer no longer carries a `scope`
+ *
+ * @param options - Extraction options including the credential offer and version config
+ * @returns Version-specific grant details containing the grant type and authorization code grant information
+ * @throws {CredentialOfferError} If grants or the authorization_code grant is missing
+ * @throws {ItWalletSpecsVersionError} If the configured version does not support credential offers
+ */
+export function extractGrantDetails(
+  options: ExtractGrantDetailsOptionsV1_3,
+): ExtractGrantDetailsResultV1_3;
+
+export function extractGrantDetails(
+  options: ExtractGrantDetailsOptionsV1_4,
+): ExtractGrantDetailsResultV1_4;
+
+export function extractGrantDetails(
+  options: ExtractGrantDetailsOptions,
+): ExtractGrantDetailsResult {
+  return dispatchExtractGrantDetails(options);
 }

--- a/packages/oid4vci/src/credential-offer/resolve-credential-offer.ts
+++ b/packages/oid4vci/src/credential-offer/resolve-credential-offer.ts
@@ -1,14 +1,50 @@
 import {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+  ItWalletSpecsVersionError,
   UnexpectedStatusCodeError,
   createFetcher,
   hasStatusOrThrow,
 } from "@pagopa/io-wallet-utils";
 
-import type { ResolveCredentialOfferOptions } from "./types";
+import type {
+  ResolveCredentialOfferOptions,
+  ResolveCredentialOfferOptionsV1_3,
+  ResolveCredentialOfferOptionsV1_4,
+} from "./types";
 
 import { CredentialOfferError } from "../errors";
 import { parseCredentialOfferUri } from "./parse-credential-offer-uri";
-import { type CredentialOffer, zCredentialOffer } from "./z-credential-offer";
+import {
+  type CredentialOffer,
+  type CredentialOfferV1_3,
+  type CredentialOfferV1_4,
+  zCredentialOfferV1_3,
+  zCredentialOfferV1_4,
+} from "./z-credential-offer";
+
+/**
+ * Parses raw credential offer JSON using the schema for the configured IT-Wallet version.
+ *
+ * @throws {ItWalletSpecsVersionError} If the configured version does not support credential offers.
+ */
+function parseCredentialOfferForVersion(
+  config: IoWalletSdkConfig,
+  data: unknown,
+): CredentialOffer {
+  switch (config.itWalletSpecsVersion) {
+    case ItWalletSpecsVersion.V1_3:
+      return zCredentialOfferV1_3.parse(data);
+    case ItWalletSpecsVersion.V1_4:
+      return zCredentialOfferV1_4.parse(data);
+    default:
+      throw new ItWalletSpecsVersionError(
+        "resolveCredentialOffer",
+        config.itWalletSpecsVersion,
+        [ItWalletSpecsVersion.V1_3, ItWalletSpecsVersion.V1_4],
+      );
+  }
+}
 
 /**
  * Resolves a credential offer from a URI or inline JSON string.
@@ -23,13 +59,19 @@ import { type CredentialOffer, zCredentialOffer } from "./z-credential-offer";
  * - `haip-vci://` - High Assurance Interoperability Profile scheme
  * - `https://` - HTTPS Universal Links (preferred)
  *
- * @param options - Resolution options containing the credential offer and fetch callback
+ * The configured IT-Wallet version selects the schema used to parse the offer:
+ * - v1.3 requires `scope` within the authorization_code grant
+ * - v1.4 no longer carries `scope`
+ *
+ * @param options - Resolution options containing the credential offer, version config, and fetch callback
  * @returns Resolved and validated credential offer object
  * @throws {CredentialOfferError} If parsing fails, HTTP request fails, or validation fails
+ * @throws {ItWalletSpecsVersionError} If the configured version does not support credential offers
  *
  * @example Resolve by-value offer (inline JSON in URI)
  * ```typescript
  * const offer = await resolveCredentialOffer({
+ *   config,
  *   credentialOffer: "openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A...",
  *   callbacks: { fetch }
  * });
@@ -39,25 +81,35 @@ import { type CredentialOffer, zCredentialOffer } from "./z-credential-offer";
  * @example Resolve by-reference offer (fetch from remote URI)
  * ```typescript
  * const offer = await resolveCredentialOffer({
+ *   config,
  *   credentialOffer: "openid-credential-offer://?credential_offer_uri=https://issuer.example.com/offers/123",
  *   callbacks: { fetch }
  * });
- * console.log(offer.grants.authorization_code.scope);
+ * console.log(offer.grants.authorization_code.issuer_state);
  * ```
  *
  * @example Resolve from direct JSON string
  * ```typescript
  * const offerJson = '{"credential_issuer":"https://issuer.example.com","credential_configuration_ids":["UniversityDegree"],"grants":{"authorization_code":{"scope":"openid"}}}';
  * const offer = await resolveCredentialOffer({
+ *   config,
  *   credentialOffer: offerJson,
  *   callbacks: { fetch }
  * });
  * ```
  */
+export function resolveCredentialOffer(
+  options: ResolveCredentialOfferOptionsV1_3,
+): Promise<CredentialOfferV1_3>;
+
+export function resolveCredentialOffer(
+  options: ResolveCredentialOfferOptionsV1_4,
+): Promise<CredentialOfferV1_4>;
+
 export async function resolveCredentialOffer(
   options: ResolveCredentialOfferOptions,
 ): Promise<CredentialOffer> {
-  const { callbacks, credentialOffer } = options;
+  const { callbacks, config, credentialOffer } = options;
 
   try {
     // Check if the input is a URI (starts with a known scheme)
@@ -73,7 +125,7 @@ export async function resolveCredentialOffer(
       if (parsed.credential_offer) {
         const decoded = decodeURIComponent(parsed.credential_offer);
         const offerJson = JSON.parse(decoded);
-        return zCredentialOffer.parse(offerJson);
+        return parseCredentialOfferForVersion(config, offerJson);
       }
 
       // By reference - fetch from remote URI
@@ -90,18 +142,19 @@ export async function resolveCredentialOffer(
         await hasStatusOrThrow(200, UnexpectedStatusCodeError)(response);
 
         const offerJson = await response.json();
-        return zCredentialOffer.parse(offerJson);
+        return parseCredentialOfferForVersion(config, offerJson);
       }
     }
 
     // Assume it's a direct JSON string
     const offerJson = JSON.parse(credentialOffer);
-    return zCredentialOffer.parse(offerJson);
+    return parseCredentialOfferForVersion(config, offerJson);
   } catch (error) {
-    // Re-throw CredentialOfferError and UnexpectedStatusCodeError as-is
+    // Re-throw known errors as-is
     if (
       error instanceof CredentialOfferError ||
-      error instanceof UnexpectedStatusCodeError
+      error instanceof UnexpectedStatusCodeError ||
+      error instanceof ItWalletSpecsVersionError
     ) {
       throw error;
     }

--- a/packages/oid4vci/src/credential-offer/types.ts
+++ b/packages/oid4vci/src/credential-offer/types.ts
@@ -123,7 +123,7 @@ interface BaseValidateCredentialOfferOptions {
    * };
    */
   credentialIssuerMetadata?: {
-    authorization_servers?: string[];
+    authorization_servers?: [string, ...string[]];
   };
 }
 

--- a/packages/oid4vci/src/credential-offer/types.ts
+++ b/packages/oid4vci/src/credential-offer/types.ts
@@ -1,9 +1,18 @@
 import type { CallbackContext } from "@openid4vc/oauth2";
+import type {
+  IoWalletSdkConfig,
+  ItWalletSpecsVersion,
+} from "@pagopa/io-wallet-utils";
 
-import type { CredentialOffer } from "./z-credential-offer";
+import type {
+  CredentialOfferV1_3,
+  CredentialOfferV1_4,
+} from "./z-credential-offer";
 
 /**
- * Options for parsing a credential offer URI
+ * Options for parsing a credential offer URI.
+ *
+ * Version-agnostic: IT-Wallet v1.3 and v1.4 share the same invocation schemes.
  */
 export interface ParseCredentialOfferUriOptions {
   /**
@@ -40,9 +49,9 @@ export interface ParseCredentialOfferUriOptions {
 }
 
 /**
- * Options for resolving a credential offer
+ * Base options shared across all resolve-credential-offer versions.
  */
-export interface ResolveCredentialOfferOptions {
+interface BaseResolveCredentialOfferOptions {
   /**
    * Callback context with fetch implementation.
    *
@@ -72,9 +81,31 @@ export interface ResolveCredentialOfferOptions {
 }
 
 /**
- * Options for validating a credential offer
+ * Options for resolving a credential offer against the IT-Wallet v1.3 schema.
  */
-export interface ValidateCredentialOfferOptions {
+export interface ResolveCredentialOfferOptionsV1_3 extends BaseResolveCredentialOfferOptions {
+  config: IoWalletSdkConfig<ItWalletSpecsVersion.V1_3>;
+}
+
+/**
+ * Options for resolving a credential offer against the IT-Wallet v1.4 schema.
+ */
+export interface ResolveCredentialOfferOptionsV1_4 extends BaseResolveCredentialOfferOptions {
+  config: IoWalletSdkConfig<ItWalletSpecsVersion.V1_4>;
+}
+
+/**
+ * Options for resolving a credential offer.
+ * The configured version selects the schema used to parse the offer.
+ */
+export type ResolveCredentialOfferOptions =
+  | ResolveCredentialOfferOptionsV1_3
+  | ResolveCredentialOfferOptionsV1_4;
+
+/**
+ * Base options shared across all validate-credential-offer versions.
+ */
+interface BaseValidateCredentialOfferOptions {
   /**
    * Optional Credential Issuer metadata for conditional validation.
    *
@@ -94,17 +125,70 @@ export interface ValidateCredentialOfferOptions {
   credentialIssuerMetadata?: {
     authorization_servers?: string[];
   };
-
-  /**
-   * The credential offer to validate against IT-Wallet specifications.
-   */
-  credentialOffer: CredentialOffer;
 }
 
 /**
- * Result of extracting grant details from a credential offer
+ * Options for validating an IT-Wallet v1.3 credential offer.
  */
-export interface ExtractGrantDetailsResult {
+export interface ValidateCredentialOfferOptionsV1_3 extends BaseValidateCredentialOfferOptions {
+  config: IoWalletSdkConfig<ItWalletSpecsVersion.V1_3>;
+  /**
+   * The credential offer to validate against IT-Wallet v1.3 specifications.
+   */
+  credentialOffer: CredentialOfferV1_3;
+}
+
+/**
+ * Options for validating an IT-Wallet v1.4 credential offer.
+ */
+export interface ValidateCredentialOfferOptionsV1_4 extends BaseValidateCredentialOfferOptions {
+  config: IoWalletSdkConfig<ItWalletSpecsVersion.V1_4>;
+  /**
+   * The credential offer to validate against IT-Wallet v1.4 specifications.
+   */
+  credentialOffer: CredentialOfferV1_4;
+}
+
+/**
+ * Options for validating a credential offer against IT-Wallet specifications.
+ */
+export type ValidateCredentialOfferOptions =
+  | ValidateCredentialOfferOptionsV1_3
+  | ValidateCredentialOfferOptionsV1_4;
+
+/**
+ * Options for extracting grant details from an IT-Wallet v1.3 credential offer.
+ */
+export interface ExtractGrantDetailsOptionsV1_3 {
+  config: IoWalletSdkConfig<ItWalletSpecsVersion.V1_3>;
+  /**
+   * The credential offer to extract grant details from.
+   */
+  credentialOffer: CredentialOfferV1_3;
+}
+
+/**
+ * Options for extracting grant details from an IT-Wallet v1.4 credential offer.
+ */
+export interface ExtractGrantDetailsOptionsV1_4 {
+  config: IoWalletSdkConfig<ItWalletSpecsVersion.V1_4>;
+  /**
+   * The credential offer to extract grant details from.
+   */
+  credentialOffer: CredentialOfferV1_4;
+}
+
+/**
+ * Options for extracting grant details from a credential offer.
+ */
+export type ExtractGrantDetailsOptions =
+  | ExtractGrantDetailsOptionsV1_3
+  | ExtractGrantDetailsOptionsV1_4;
+
+/**
+ * Result of extracting grant details from an IT-Wallet v1.3 credential offer.
+ */
+export interface ExtractGrantDetailsResultV1_3 {
   /**
    * Details of the authorization code grant.
    */
@@ -130,8 +214,45 @@ export interface ExtractGrantDetailsResult {
 
   /**
    * The type of grant present in the credential offer.
-   *
-   * IT-Wallet v1.3 only supports "authorization_code".
+   * IT-Wallet only supports "authorization_code".
    */
   grantType: "authorization_code";
 }
+
+/**
+ * Result of extracting grant details from an IT-Wallet v1.4 credential offer.
+ *
+ * Difference from v1.3: the credential offer no longer carries a `scope`;
+ * the wallet derives it from the credential configuration metadata instead.
+ */
+export interface ExtractGrantDetailsResultV1_4 {
+  /**
+   * Details of the authorization code grant.
+   */
+  authorizationCodeGrant: {
+    /**
+     * HTTPS URL of the Authorization Server.
+     * OPTIONAL, but REQUIRED when the Credential Issuer uses multiple Authorization Servers.
+     */
+    authorizationServer?: string;
+
+    /**
+     * String value representing the issuer state.
+     * OPTIONAL. Used to correlate the authorization request with the credential offer.
+     */
+    issuerState?: string;
+  };
+
+  /**
+   * The type of grant present in the credential offer.
+   * IT-Wallet only supports "authorization_code".
+   */
+  grantType: "authorization_code";
+}
+
+/**
+ * Result of extracting grant details from a credential offer.
+ */
+export type ExtractGrantDetailsResult =
+  | ExtractGrantDetailsResultV1_3
+  | ExtractGrantDetailsResultV1_4;

--- a/packages/oid4vci/src/credential-offer/v1.3/z-credential-offer.ts
+++ b/packages/oid4vci/src/credential-offer/v1.3/z-credential-offer.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+/**
+ * Authorization Code Grant schema
+ * IT-Wallet v1.3 specification: Section 5.1
+ *
+ * The authorization_code grant is REQUIRED for IT-Wallet v1.3.
+ * Pre-authorized code grant is NOT supported.
+ */
+export const zAuthorizationCodeGrantV1_3 = z.object({
+  /**
+   * CONDITIONALLY REQUIRED. HTTPS URL of the Authorization Server.
+   * REQUIRED only when the Credential Issuer uses multiple Authorization Servers.
+   * If present, MUST match one of the authorization_servers in the Credential Issuer metadata.
+   */
+  authorization_server: z.url().optional(),
+
+  /**
+   * OPTIONAL. String value representing the issuer state.
+   * Used to correlate the authorization request with the credential offer.
+   */
+  issuer_state: z.string().optional(),
+
+  /**
+   * REQUIRED. OAuth 2.0 scope value.
+   * Defines the scope of access requested by the credential offer.
+   */
+  scope: z.string(),
+});
+
+/**
+ * Credential Offer Grants schema
+ * IT-Wallet v1.3 specification: Section 5.1
+ *
+ * The grants object is REQUIRED for IT-Wallet v1.3.
+ * Only authorization_code grant is supported.
+ */
+export const zCredentialOfferGrantsV1_3 = z.object({
+  /**
+   * REQUIRED. Authorization Code grant details.
+   * IT-Wallet v1.3 only supports authorization_code grant.
+   */
+  authorization_code: zAuthorizationCodeGrantV1_3,
+});
+
+/**
+ * Credential Offer schema
+ * IT-Wallet v1.3 specification: Section 5.1
+ *
+ * Represents a credential offer from a Credential Issuer to a wallet.
+ */
+export const zCredentialOfferV1_3 = z.object({
+  /**
+   * REQUIRED. Array of credential configuration identifiers.
+   * References the types of credentials offered as defined in the Credential Issuer metadata.
+   */
+  credential_configuration_ids: z.array(z.string()).min(1),
+
+  /**
+   * REQUIRED. HTTPS URL of the Credential Issuer.
+   * The Credential Issuer from which the wallet will request credentials.
+   */
+  credential_issuer: z.url(),
+
+  /**
+   * REQUIRED. Grant information for the credential offer.
+   * IT-Wallet v1.3 requires authorization_code grant.
+   */
+  grants: zCredentialOfferGrantsV1_3,
+});
+
+export type AuthorizationCodeGrantV1_3 = z.infer<
+  typeof zAuthorizationCodeGrantV1_3
+>;
+export type CredentialOfferGrantsV1_3 = z.infer<
+  typeof zCredentialOfferGrantsV1_3
+>;
+export type CredentialOfferV1_3 = z.infer<typeof zCredentialOfferV1_3>;

--- a/packages/oid4vci/src/credential-offer/v1.4/z-credential-offer.ts
+++ b/packages/oid4vci/src/credential-offer/v1.4/z-credential-offer.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+/**
+ * Authorization Code Grant schema
+ * IT-Wallet v1.4 specification: Section 5.1
+ *
+ * The authorization_code grant is REQUIRED for IT-Wallet v1.4.
+ * Pre-authorized code grant is NOT supported.
+ *
+ * Difference from v1.3: the `scope` parameter has been removed from the
+ * Credential Offer. The wallet derives the scope from the credential
+ * configuration metadata instead. A stray `scope` value is silently dropped.
+ */
+export const zAuthorizationCodeGrantV1_4 = z.object({
+  /**
+   * CONDITIONALLY REQUIRED. HTTPS URL of the Authorization Server.
+   * REQUIRED only when the Credential Issuer uses multiple Authorization Servers.
+   * If present, MUST match one of the authorization_servers in the Credential Issuer metadata.
+   */
+  authorization_server: z.url().optional(),
+
+  /**
+   * OPTIONAL. String value representing the issuer state.
+   * Used to correlate the authorization request with the credential offer.
+   */
+  issuer_state: z.string().optional(),
+});
+
+/**
+ * Credential Offer Grants schema
+ * IT-Wallet v1.4 specification: Section 5.1
+ *
+ * The grants object is REQUIRED for IT-Wallet v1.4.
+ * Only authorization_code grant is supported.
+ */
+export const zCredentialOfferGrantsV1_4 = z.object({
+  /**
+   * REQUIRED. Authorization Code grant details.
+   * IT-Wallet v1.4 only supports authorization_code grant.
+   */
+  authorization_code: zAuthorizationCodeGrantV1_4,
+});
+
+/**
+ * Credential Offer schema
+ * IT-Wallet v1.4 specification: Section 5.1
+ *
+ * Represents a credential offer from a Credential Issuer to a wallet.
+ */
+export const zCredentialOfferV1_4 = z.object({
+  /**
+   * REQUIRED. Array of credential configuration identifiers.
+   * References the types of credentials offered as defined in the Credential Issuer metadata.
+   */
+  credential_configuration_ids: z.array(z.string()).min(1),
+
+  /**
+   * REQUIRED. HTTPS URL of the Credential Issuer.
+   * The Credential Issuer from which the wallet will request credentials.
+   */
+  credential_issuer: z.url(),
+
+  /**
+   * REQUIRED. Grant information for the credential offer.
+   * IT-Wallet v1.4 requires authorization_code grant.
+   */
+  grants: zCredentialOfferGrantsV1_4,
+});
+
+export type AuthorizationCodeGrantV1_4 = z.infer<
+  typeof zAuthorizationCodeGrantV1_4
+>;
+export type CredentialOfferGrantsV1_4 = z.infer<
+  typeof zCredentialOfferGrantsV1_4
+>;
+export type CredentialOfferV1_4 = z.infer<typeof zCredentialOfferV1_4>;

--- a/packages/oid4vci/src/credential-offer/validate-credential-offer.ts
+++ b/packages/oid4vci/src/credential-offer/validate-credential-offer.ts
@@ -14,12 +14,56 @@ import type { CredentialOffer } from "./z-credential-offer";
 import { CredentialOfferError } from "../errors";
 
 /**
+ * Ensures an authorization server selected from a credential offer is one of the
+ * `authorization_servers` declared by the Credential Issuer metadata.
+ *
+ * No-op when no authorization server was selected and the issuer specifies at least
+ * two authorization servers. This check mirrors (and runs ahead of) the credential
+ * offer validation step, so a metadata fetch driven by an offer fails fast on a
+ * mismatched authorization server.
+ *
+ * @throws {CredentialOfferError} If a selected authorization server is absent
+ *   from (or unsupported by) the issuer's `authorization_servers` list.
+ */
+export function assertAuthorizationServerAllowed(
+  authorizationServer: string | undefined,
+  authorizationServers: readonly [string, ...string[]] | undefined,
+): void {
+  if (!authorizationServer) {
+    if (authorizationServers && authorizationServers.length > 1) {
+      throw new CredentialOfferError(
+        "authorization_server is REQUIRED when Credential Issuer uses multiple Authorization Servers",
+      );
+    }
+    return;
+  }
+
+  if (!authorizationServers) {
+    throw new CredentialOfferError(
+      "credential offer specified an `authorization_server` but issuer metadata doesn't contain `authorization_servers`",
+    );
+  }
+
+  if (authorizationServers.length === 1) {
+    throw new CredentialOfferError(
+      "credential offer specified an `authorization_server` but issuer metadata's `authorization_servers` contains only an element",
+    );
+  }
+
+  if (!authorizationServers.includes(authorizationServer)) {
+    throw new CredentialOfferError(
+      `authorization_server '${authorizationServer}' does not match Credential Issuer metadata. Valid servers: ${authorizationServers.join(", ")}`,
+    );
+  }
+}
+
+/**
  * Validations shared across all IT-Wallet credential offer versions.
  *
  * @throws {CredentialOfferError} If any shared validation rule fails.
  */
 function validateBaseCredentialOffer(options: {
-  credentialIssuerMetadata?: { authorization_servers?: string[] };
+  credentialIssuerMetadata?: { authorization_servers?: [string, ...string[]] };
   credentialOffer: CredentialOffer;
   versionLabel: string;
 }): void {
@@ -53,28 +97,10 @@ function validateBaseCredentialOffer(options: {
     );
   }
 
-  // Conditional validation for authorization_server
-  // REQUIRED only when CI uses multiple authorization servers
-  if (credentialIssuerMetadata?.authorization_servers) {
-    const authServers = credentialIssuerMetadata.authorization_servers;
-
-    // If multiple authorization servers exist, authorization_server must be present
-    if (authServers.length > 1 && !authCodeGrant.authorization_server) {
-      throw new CredentialOfferError(
-        "authorization_server is REQUIRED when Credential Issuer uses multiple Authorization Servers",
-      );
-    }
-
-    // If authorization_server is present, validate it matches metadata
-    if (
-      authCodeGrant.authorization_server &&
-      !authServers.includes(authCodeGrant.authorization_server)
-    ) {
-      throw new CredentialOfferError(
-        `authorization_server '${authCodeGrant.authorization_server}' does not match Credential Issuer metadata. Valid servers: ${authServers.join(", ")}`,
-      );
-    }
-  }
+  assertAuthorizationServerAllowed(
+    authCodeGrant.authorization_server,
+    credentialIssuerMetadata?.authorization_servers,
+  );
 }
 
 async function validateCredentialOfferV1_3(

--- a/packages/oid4vci/src/credential-offer/validate-credential-offer.ts
+++ b/packages/oid4vci/src/credential-offer/validate-credential-offer.ts
@@ -1,32 +1,29 @@
-import type { ValidateCredentialOfferOptions } from "./types";
+import {
+  ItWalletSpecsVersion,
+  ItWalletSpecsVersionError,
+  createVersionDispatcher,
+} from "@pagopa/io-wallet-utils";
+
+import type {
+  ValidateCredentialOfferOptions,
+  ValidateCredentialOfferOptionsV1_3,
+  ValidateCredentialOfferOptionsV1_4,
+} from "./types";
+import type { CredentialOffer } from "./z-credential-offer";
 
 import { CredentialOfferError } from "../errors";
 
 /**
- * Validates a credential offer against IT-Wallet v1.3 specifications.
+ * Validations shared across all IT-Wallet credential offer versions.
  *
- * This function performs comprehensive validation of a credential offer to ensure
- * compliance with the IT-Wallet v1.3 requirements (Section 5.1):
- *
- * **Required validations:**
- * - `credential_issuer` must be an HTTPS URL
- * - `credential_configuration_ids` must contain at least one identifier
- * - `grants` object is REQUIRED for IT-Wallet v1.3
- * - `authorization_code` grant is REQUIRED (pre-authorized code is NOT supported)
- * - `scope` is REQUIRED within the authorization_code grant
- *
- * **Conditional validations:**
- * - `authorization_server` is REQUIRED when the Credential Issuer uses multiple Authorization Servers
- * - If `authorization_server` is present, it MUST match one of the servers in the Credential Issuer metadata
- *
- * @param options - Validation options containing the credential offer, config, and optional metadata
- * @returns Resolves when the credential offer satisfies IT-Wallet validation rules.
- * @throws {CredentialOfferError} If any validation rule fails
+ * @throws {CredentialOfferError} If any shared validation rule fails.
  */
-export async function validateCredentialOffer(
-  options: ValidateCredentialOfferOptions,
-): Promise<void> {
-  const { credentialIssuerMetadata, credentialOffer } = options;
+function validateBaseCredentialOffer(options: {
+  credentialIssuerMetadata?: { authorization_servers?: string[] };
+  credentialOffer: CredentialOffer;
+  versionLabel: string;
+}): void {
+  const { credentialIssuerMetadata, credentialOffer, versionLabel } = options;
 
   // Validate credential_issuer is HTTPS
   if (!credentialOffer.credential_issuer.startsWith("https://")) {
@@ -40,23 +37,20 @@ export async function validateCredentialOffer(
     );
   }
 
-  // IT-Wallet v1.3: grants is REQUIRED
+  // grants is REQUIRED
   if (!credentialOffer.grants) {
-    throw new CredentialOfferError("grants is REQUIRED for IT-Wallet v1.3");
+    throw new CredentialOfferError(
+      `grants is REQUIRED for IT-Wallet ${versionLabel}`,
+    );
   }
 
   const authCodeGrant = credentialOffer.grants.authorization_code;
 
-  // IT-Wallet v1.3: authorization_code grant is REQUIRED
+  // authorization_code grant is REQUIRED
   if (!authCodeGrant) {
     throw new CredentialOfferError(
-      "authorization_code grant is REQUIRED for IT-Wallet v1.3",
+      `authorization_code grant is REQUIRED for IT-Wallet ${versionLabel}`,
     );
-  }
-
-  // Validate scope is present (REQUIRED in authorization_code)
-  if (!authCodeGrant.scope) {
-    throw new CredentialOfferError("authorization_code.scope is REQUIRED");
   }
 
   // Conditional validation for authorization_server
@@ -72,12 +66,84 @@ export async function validateCredentialOffer(
     }
 
     // If authorization_server is present, validate it matches metadata
-    if (authCodeGrant.authorization_server) {
-      if (!authServers.includes(authCodeGrant.authorization_server)) {
-        throw new CredentialOfferError(
-          `authorization_server '${authCodeGrant.authorization_server}' does not match Credential Issuer metadata. Valid servers: ${authServers.join(", ")}`,
-        );
-      }
+    if (
+      authCodeGrant.authorization_server &&
+      !authServers.includes(authCodeGrant.authorization_server)
+    ) {
+      throw new CredentialOfferError(
+        `authorization_server '${authCodeGrant.authorization_server}' does not match Credential Issuer metadata. Valid servers: ${authServers.join(", ")}`,
+      );
     }
   }
+}
+
+async function validateCredentialOfferV1_3(
+  options: ValidateCredentialOfferOptionsV1_3,
+): Promise<void> {
+  validateBaseCredentialOffer({
+    credentialIssuerMetadata: options.credentialIssuerMetadata,
+    credentialOffer: options.credentialOffer,
+    versionLabel: "v1.3",
+  });
+
+  // IT-Wallet v1.3: scope is REQUIRED within the authorization_code grant
+  if (!options.credentialOffer.grants.authorization_code.scope) {
+    throw new CredentialOfferError("authorization_code.scope is REQUIRED");
+  }
+}
+
+async function validateCredentialOfferV1_4(
+  options: ValidateCredentialOfferOptionsV1_4,
+): Promise<void> {
+  // IT-Wallet v1.4: the credential offer no longer carries a `scope`
+  validateBaseCredentialOffer({
+    credentialIssuerMetadata: options.credentialIssuerMetadata,
+    credentialOffer: options.credentialOffer,
+    versionLabel: "v1.4",
+  });
+}
+
+const dispatchValidateCredentialOffer = createVersionDispatcher<
+  ValidateCredentialOfferOptions,
+  Promise<void>
+>({
+  [ItWalletSpecsVersion.V1_0]: () => {
+    throw new ItWalletSpecsVersionError(
+      "validateCredentialOffer",
+      ItWalletSpecsVersion.V1_0,
+      [ItWalletSpecsVersion.V1_3, ItWalletSpecsVersion.V1_4],
+    );
+  },
+  [ItWalletSpecsVersion.V1_3]: (o) =>
+    validateCredentialOfferV1_3(o as ValidateCredentialOfferOptionsV1_3),
+  [ItWalletSpecsVersion.V1_4]: (o) =>
+    validateCredentialOfferV1_4(o as ValidateCredentialOfferOptionsV1_4),
+});
+
+/**
+ * Validates a credential offer against IT-Wallet specifications for the configured version.
+ *
+ * **Required validations (all versions):**
+ * - `credential_issuer` must be an HTTPS URL
+ * - `credential_configuration_ids` must contain at least one identifier
+ * - `grants` object is REQUIRED
+ * - `authorization_code` grant is REQUIRED (pre-authorized code is NOT supported)
+ *
+ * **Version-specific validations:**
+ * - v1.3: `scope` is REQUIRED within the authorization_code grant
+ * - v1.4: the credential offer no longer carries a `scope`
+ *
+ * **Conditional validations:**
+ * - `authorization_server` is REQUIRED when the Credential Issuer uses multiple Authorization Servers
+ * - If `authorization_server` is present, it MUST match one of the servers in the Credential Issuer metadata
+ *
+ * @param options - Validation options containing the credential offer, config, and optional metadata
+ * @returns Resolves when the credential offer satisfies IT-Wallet validation rules.
+ * @throws {CredentialOfferError} If any validation rule fails
+ * @throws {ItWalletSpecsVersionError} If the configured version does not support credential offers
+ */
+export async function validateCredentialOffer(
+  options: ValidateCredentialOfferOptions,
+): Promise<void> {
+  return dispatchValidateCredentialOffer(options);
 }

--- a/packages/oid4vci/src/credential-offer/z-credential-offer.ts
+++ b/packages/oid4vci/src/credential-offer/z-credential-offer.ts
@@ -1,77 +1,50 @@
 import { z } from "zod";
 
-/**
- * Authorization Code Grant schema
- * IT-Wallet v1.3 specification: Section 5.1
- *
- * The authorization_code grant is REQUIRED for IT-Wallet v1.3.
- * Pre-authorized code grant is NOT supported.
- */
-export const zAuthorizationCodeGrant = z.object({
-  /**
-   * CONDITIONALLY REQUIRED. HTTPS URL of the Authorization Server.
-   * REQUIRED only when the Credential Issuer uses multiple Authorization Servers.
-   * If present, MUST match one of the authorization_servers in the Credential Issuer metadata.
-   */
-  authorization_server: z.url().optional(),
+import {
+  type AuthorizationCodeGrantV1_3,
+  type CredentialOfferGrantsV1_3,
+  type CredentialOfferV1_3,
+  zAuthorizationCodeGrantV1_3,
+  zCredentialOfferGrantsV1_3,
+  zCredentialOfferV1_3,
+} from "./v1.3/z-credential-offer";
+import {
+  type AuthorizationCodeGrantV1_4,
+  type CredentialOfferGrantsV1_4,
+  type CredentialOfferV1_4,
+  zAuthorizationCodeGrantV1_4,
+  zCredentialOfferGrantsV1_4,
+  zCredentialOfferV1_4,
+} from "./v1.4/z-credential-offer";
 
-  /**
-   * OPTIONAL. String value representing the issuer state.
-   * Used to correlate the authorization request with the credential offer.
-   */
-  issuer_state: z.string().optional(),
-
-  /**
-   * REQUIRED. OAuth 2.0 scope value.
-   * Defines the scope of access requested by the credential offer.
-   */
-  scope: z.string(),
-});
-
-/**
- * Credential Offer Grants schema
- * IT-Wallet v1.3 specification: Section 5.1
- *
- * The grants object is REQUIRED for IT-Wallet v1.3.
- * Only authorization_code grant is supported.
- */
-export const zCredentialOfferGrants = z.object({
-  /**
-   * REQUIRED. Authorization Code grant details.
-   * IT-Wallet v1.3 only supports authorization_code grant.
-   */
-  authorization_code: zAuthorizationCodeGrant,
-});
-
-/**
- * Credential Offer schema
- * IT-Wallet v1.3 specification: Section 5.1
- *
- * Represents a credential offer from a Credential Issuer to a wallet.
- */
-export const zCredentialOffer = z.object({
-  /**
-   * REQUIRED. Array of credential configuration identifiers.
-   * References the types of credentials offered as defined in the Credential Issuer metadata.
-   */
-  credential_configuration_ids: z.array(z.string()).min(1),
-
-  /**
-   * REQUIRED. HTTPS URL of the Credential Issuer.
-   * The Credential Issuer from which the wallet will request credentials.
-   */
-  credential_issuer: z.url(),
-
-  /**
-   * REQUIRED. Grant information for the credential offer.
-   * IT-Wallet v1.3 requires authorization_code grant.
-   */
-  grants: zCredentialOfferGrants,
-});
+// Re-export version-specific schemas and types.
+// v1.4 forks only the authorization_code grant (no `scope`); everything else is identical to v1.3.
+export {
+  zAuthorizationCodeGrantV1_3,
+  zCredentialOfferGrantsV1_3,
+  zCredentialOfferV1_3,
+};
+export {
+  zAuthorizationCodeGrantV1_4,
+  zCredentialOfferGrantsV1_4,
+  zCredentialOfferV1_4,
+};
+export type {
+  AuthorizationCodeGrantV1_3,
+  CredentialOfferGrantsV1_3,
+  CredentialOfferV1_3,
+};
+export type {
+  AuthorizationCodeGrantV1_4,
+  CredentialOfferGrantsV1_4,
+  CredentialOfferV1_4,
+};
 
 /**
  * Credential Offer URI schema
  * Represents a parsed credential offer URI with scheme and parameters.
+ *
+ * Version-agnostic: IT-Wallet v1.3 and v1.4 share the same invocation schemes.
  *
  * Supports three URL schemes:
  * - openid-credential-offer:// - Standard OpenID scheme (custom URL scheme)
@@ -107,19 +80,26 @@ export const zCredentialOfferUri = z
   });
 
 /**
- * TypeScript type for Authorization Code Grant
+ * TypeScript type for Authorization Code Grant.
+ * Union across supported IT-Wallet versions.
  */
-export type AuthorizationCodeGrant = z.infer<typeof zAuthorizationCodeGrant>;
+export type AuthorizationCodeGrant =
+  | AuthorizationCodeGrantV1_3
+  | AuthorizationCodeGrantV1_4;
 
 /**
- * TypeScript type for Credential Offer Grants
+ * TypeScript type for Credential Offer Grants.
+ * Union across supported IT-Wallet versions.
  */
-export type CredentialOfferGrants = z.infer<typeof zCredentialOfferGrants>;
+export type CredentialOfferGrants =
+  | CredentialOfferGrantsV1_3
+  | CredentialOfferGrantsV1_4;
 
 /**
- * TypeScript type for Credential Offer
+ * TypeScript type for Credential Offer.
+ * Union across supported IT-Wallet versions.
  */
-export type CredentialOffer = z.infer<typeof zCredentialOffer>;
+export type CredentialOffer = CredentialOfferV1_3 | CredentialOfferV1_4;
 
 /**
  * TypeScript type for Credential Offer URI

--- a/packages/oid4vci/src/index.ts
+++ b/packages/oid4vci/src/index.ts
@@ -5,17 +5,40 @@ export { extractGrantDetails } from "./credential-offer/extract-grant-details";
 export { parseCredentialOfferUri } from "./credential-offer/parse-credential-offer-uri";
 export { resolveCredentialOffer } from "./credential-offer/resolve-credential-offer";
 export type {
+  ExtractGrantDetailsOptions,
+  ExtractGrantDetailsOptionsV1_3,
+  ExtractGrantDetailsOptionsV1_4,
   ExtractGrantDetailsResult,
+  ExtractGrantDetailsResultV1_3,
+  ExtractGrantDetailsResultV1_4,
   ParseCredentialOfferUriOptions,
   ResolveCredentialOfferOptions,
+  ResolveCredentialOfferOptionsV1_3,
+  ResolveCredentialOfferOptionsV1_4,
   ValidateCredentialOfferOptions,
+  ValidateCredentialOfferOptionsV1_3,
+  ValidateCredentialOfferOptionsV1_4,
 } from "./credential-offer/types";
 export { validateCredentialOffer } from "./credential-offer/validate-credential-offer";
 export type {
   AuthorizationCodeGrant,
+  AuthorizationCodeGrantV1_3,
+  AuthorizationCodeGrantV1_4,
   CredentialOffer,
   CredentialOfferGrants,
+  CredentialOfferGrantsV1_3,
+  CredentialOfferGrantsV1_4,
   CredentialOfferUri,
+  CredentialOfferV1_3,
+  CredentialOfferV1_4,
+} from "./credential-offer/z-credential-offer";
+export {
+  zAuthorizationCodeGrantV1_3,
+  zAuthorizationCodeGrantV1_4,
+  zCredentialOfferGrantsV1_3,
+  zCredentialOfferGrantsV1_4,
+  zCredentialOfferV1_3,
+  zCredentialOfferV1_4,
 } from "./credential-offer/z-credential-offer";
 export * from "./credential-request/create-credential-request";
 export * from "./credential-request/parse-credential-request";

--- a/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
+++ b/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
@@ -654,7 +654,10 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
           oauth_authorization_server: coLocatedAuthorizationServerMetadata,
           openid_credential_issuer: {
             ...credentialIssuerMetadata,
-            authorization_servers: ["https://issuer.example.it"],
+            authorization_servers: [
+              "https://issuer.example.it",
+              "https://as2.example.it",
+            ],
           },
         },
         sub: "https://issuer.example.it",
@@ -689,7 +692,10 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
           oauth_authorization_server: authorizationServerMetadata,
           openid_credential_issuer: {
             ...credentialIssuerMetadata,
-            authorization_servers: ["https://as2.example.it"],
+            authorization_servers: [
+              "https://issuer.example.it",
+              "https://as2.example.it",
+            ],
           },
         },
         sub: "https://issuer.example.it",

--- a/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
+++ b/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
@@ -636,19 +636,26 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
     });
   });
 
+  // A co-located issuer attests its own authorization server inline, with an
+  // issuer value equal to the Credential Issuer identifier.
+  const coLocatedAuthorizationServerMetadata = {
+    ...authorizationServerMetadata,
+    issuer: "https://issuer.example.it",
+  };
+
   describe("federation path", () => {
-    it("should accept the inline authorization server even when it is not in the issuer's list", async () => {
-      // Inline AS matches the selection: accepted via the inline shortcut,
-      // ahead of (and regardless of) the authorization_servers list check.
+    it("should not perform a secondary fetch when the offer selects the credential issuer itself", async () => {
       const federationPayload = {
         exp: 1_700_003_600,
         iat: 1_700_000_000,
         iss: "https://issuer.example.it",
         jwks: mockJwks,
         metadata: {
-          oauth_authorization_server: authorizationServerMetadata,
-          // No authorization_servers declared on the credential issuer
-          openid_credential_issuer: credentialIssuerMetadata,
+          oauth_authorization_server: coLocatedAuthorizationServerMetadata,
+          openid_credential_issuer: {
+            ...credentialIssuerMetadata,
+            authorization_servers: ["https://issuer.example.it"],
+          },
         },
         sub: "https://issuer.example.it",
       };
@@ -660,14 +667,14 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
 
       const result = await fetchMetadata({
         ...baseOptions,
-        authorizationServer: "https://auth.example.it",
+        authorizationServer: "https://issuer.example.it",
       });
 
       expect(result.discoveredVia).toBe("federation");
       expect(result.metadata.oauth_authorization_server?.issuer).toBe(
-        "https://auth.example.it",
+        "https://issuer.example.it",
       );
-      // Selected AS matches the inline one: no secondary federation fetch
+      // Selected AS is the credential issuer itself: no secondary fetch
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -795,6 +802,103 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
         }),
       ).rejects.toThrow(CredentialOfferError);
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    describe("without an offer-selected authorization server", () => {
+      it("should not perform a secondary fetch when the issuer lists itself", async () => {
+        const federationPayload = {
+          exp: 1_700_003_600,
+          iat: 1_700_000_000,
+          iss: "https://issuer.example.it",
+          jwks: mockJwks,
+          metadata: {
+            oauth_authorization_server: coLocatedAuthorizationServerMetadata,
+            openid_credential_issuer: {
+              ...credentialIssuerMetadata,
+              authorization_servers: [
+                "https://as2.example.it",
+                "https://issuer.example.it",
+              ],
+            },
+          },
+          sub: "https://issuer.example.it",
+        };
+
+        mockFetch.mockResolvedValueOnce({
+          status: 200,
+          text: vi
+            .fn()
+            .mockResolvedValue(buildFederationJwt(federationPayload)),
+        });
+
+        const result = await fetchMetadata(baseOptions);
+
+        expect(result.discoveredVia).toBe("federation");
+        expect(result.metadata.oauth_authorization_server?.issuer).toBe(
+          "https://issuer.example.it",
+        );
+        // Credential issuer is one of the declared servers: no secondary fetch
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it("should resolve the first declared server when the issuer does not list itself", async () => {
+        const issuerFederationPayload = {
+          exp: 1_700_003_600,
+          iat: 1_700_000_000,
+          iss: "https://issuer.example.it",
+          jwks: mockJwks,
+          metadata: {
+            // Inline block present but the issuer is not among the declared
+            // servers: it must be discarded.
+            oauth_authorization_server: authorizationServerMetadata,
+            openid_credential_issuer: {
+              ...credentialIssuerMetadata,
+              authorization_servers: ["https://as2.example.it"],
+            },
+          },
+          sub: "https://issuer.example.it",
+        };
+        const authorizationServerFederationPayload = {
+          exp: 1_700_003_600,
+          iat: 1_700_000_000,
+          iss: "https://as2.example.it",
+          jwks: mockJwks,
+          metadata: {
+            oauth_authorization_server: {
+              ...authorizationServerMetadata,
+              issuer: "https://as2.example.it",
+            },
+          },
+          sub: "https://as2.example.it",
+        };
+
+        mockFetch.mockResolvedValueOnce({
+          status: 200,
+          text: vi
+            .fn()
+            .mockResolvedValue(buildFederationJwt(issuerFederationPayload)),
+        });
+        mockFetch.mockResolvedValueOnce({
+          status: 200,
+          text: vi
+            .fn()
+            .mockResolvedValue(
+              buildFederationJwt(authorizationServerFederationPayload),
+            ),
+        });
+
+        const result = await fetchMetadata(baseOptions);
+
+        expect(result.discoveredVia).toBe("federation");
+        expect(result.metadata.oauth_authorization_server?.issuer).toBe(
+          "https://as2.example.it",
+        );
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          2,
+          "https://as2.example.it/.well-known/openid-federation",
+        );
+      });
     });
   });
 });

--- a/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
+++ b/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import {
   IoWalletSdkConfig,
   ItWalletSpecsVersion,
@@ -5,8 +6,9 @@ import {
 } from "@pagopa/io-wallet-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { FetchMetadataError } from "../../errors";
+import { CredentialOfferError, FetchMetadataError } from "../../errors";
 import { FetchMetadataOptions, fetchMetadata } from "../fetch-metadata";
+import { MetadataResponseV1_3 } from "../z-metadata-response";
 
 const mockFetch = vi.fn();
 
@@ -549,6 +551,251 @@ describe("fetchMetadata - base URL with path segment", () => {
       3,
       "https://auth.example.it/v1/.well-known/oauth-authorization-server",
     );
+  });
+});
+
+describe("fetchMetadata - offer authorization server compatibility", () => {
+  describe("oid4vci fallback path", () => {
+    it("should fetch the selected authorization server when it is in the issuer's authorization_servers list", async () => {
+      const issuerWithAuthServers = {
+        ...credentialIssuerMetadata,
+        authorization_servers: [
+          "https://auth.example.it",
+          "https://other.example.it",
+        ],
+      };
+
+      // Federation fails
+      mockFetch.mockResolvedValueOnce({ status: 500 });
+      // Credential issuer succeeds
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue(issuerWithAuthServers),
+        status: 200,
+      });
+      // Selected auth server succeeds
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue(authorizationServerMetadata),
+        status: 200,
+      });
+
+      const result = await fetchMetadata({
+        ...baseOptions,
+        authorizationServer: "https://auth.example.it",
+      });
+
+      expect(result.discoveredVia).toBe("oid4vci");
+      expect(result.metadata.oauth_authorization_server?.issuer).toBe(
+        "https://auth.example.it",
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        3,
+        "https://auth.example.it/.well-known/oauth-authorization-server",
+      );
+    });
+
+    it("should throw CredentialOfferError when the selected authorization server is not in the issuer's list", async () => {
+      const issuerWithAuthServers = {
+        ...credentialIssuerMetadata,
+        authorization_servers: ["https://auth.example.it"],
+      };
+
+      // Federation fails
+      mockFetch.mockResolvedValueOnce({ status: 500 });
+      // Credential issuer succeeds
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue(issuerWithAuthServers),
+        status: 200,
+      });
+
+      await expect(
+        fetchMetadata({
+          ...baseOptions,
+          authorizationServer: "https://attacker.example.it",
+        }),
+      ).rejects.toThrow(CredentialOfferError);
+      // No auth-server fetch should fire: federation + credential-issuer only
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw CredentialOfferError when an authorization server is selected but the issuer declares none", async () => {
+      // Federation fails
+      mockFetch.mockResolvedValueOnce({ status: 500 });
+      // Credential issuer succeeds without an authorization_servers list
+      mockFetch.mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue(credentialIssuerMetadata),
+        status: 200,
+      });
+
+      await expect(
+        fetchMetadata({
+          ...baseOptions,
+          authorizationServer: "https://auth.example.it",
+        }),
+      ).rejects.toThrow(CredentialOfferError);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("federation path", () => {
+    it("should accept the inline authorization server even when it is not in the issuer's list", async () => {
+      // Inline AS matches the selection: accepted via the inline shortcut,
+      // ahead of (and regardless of) the authorization_servers list check.
+      const federationPayload = {
+        exp: 1_700_003_600,
+        iat: 1_700_000_000,
+        iss: "https://issuer.example.it",
+        jwks: mockJwks,
+        metadata: {
+          oauth_authorization_server: authorizationServerMetadata,
+          // No authorization_servers declared on the credential issuer
+          openid_credential_issuer: credentialIssuerMetadata,
+        },
+        sub: "https://issuer.example.it",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        text: vi.fn().mockResolvedValue(buildFederationJwt(federationPayload)),
+      });
+
+      const result = await fetchMetadata({
+        ...baseOptions,
+        authorizationServer: "https://auth.example.it",
+      });
+
+      expect(result.discoveredVia).toBe("federation");
+      expect(result.metadata.oauth_authorization_server?.issuer).toBe(
+        "https://auth.example.it",
+      );
+      // Selected AS matches the inline one: no secondary federation fetch
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should resolve a non-inline authorization server via federation when it is in the issuer's list", async () => {
+      const issuerFederationPayload = {
+        exp: 1_700_003_600,
+        iat: 1_700_000_000,
+        iss: "https://issuer.example.it",
+        jwks: mockJwks,
+        metadata: {
+          // Inline AS differs from the selected one
+          oauth_authorization_server: authorizationServerMetadata,
+          openid_credential_issuer: {
+            ...credentialIssuerMetadata,
+            authorization_servers: ["https://as2.example.it"],
+          },
+        },
+        sub: "https://issuer.example.it",
+      };
+      const authorizationServerFederationPayload = {
+        exp: 1_700_003_600,
+        iat: 1_700_000_000,
+        iss: "https://as2.example.it",
+        jwks: mockJwks,
+        metadata: {
+          oauth_authorization_server: {
+            ...authorizationServerMetadata,
+            issuer: "https://as2.example.it",
+          },
+        },
+        sub: "https://as2.example.it",
+      };
+
+      // Issuer federation succeeds
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        text: vi
+          .fn()
+          .mockResolvedValue(buildFederationJwt(issuerFederationPayload)),
+      });
+      // Selected authorization server federation succeeds
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        text: vi
+          .fn()
+          .mockResolvedValue(
+            buildFederationJwt(authorizationServerFederationPayload),
+          ),
+      });
+
+      const result = await fetchMetadata({
+        ...baseOptions,
+        authorizationServer: "https://as2.example.it",
+      });
+
+      expect(result.discoveredVia).toBe("federation");
+      expect(result.metadata.oauth_authorization_server?.issuer).toBe(
+        "https://as2.example.it",
+      );
+      expect(
+        (result as MetadataResponseV1_3).authorization_server_federation_claims
+          ?.iss,
+      ).toBe("https://as2.example.it");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        "https://as2.example.it/.well-known/openid-federation",
+      );
+    });
+
+    it("should throw CredentialOfferError when a non-inline authorization server is not in the issuer's list", async () => {
+      const federationPayload = {
+        exp: 1_700_003_600,
+        iat: 1_700_000_000,
+        iss: "https://issuer.example.it",
+        jwks: mockJwks,
+        metadata: {
+          oauth_authorization_server: authorizationServerMetadata,
+          openid_credential_issuer: {
+            ...credentialIssuerMetadata,
+            authorization_servers: ["https://auth.example.it"],
+          },
+        },
+        sub: "https://issuer.example.it",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        text: vi.fn().mockResolvedValue(buildFederationJwt(federationPayload)),
+      });
+
+      await expect(
+        fetchMetadata({
+          ...baseOptions,
+          authorizationServer: "https://attacker.example.it",
+        }),
+      ).rejects.toThrow(CredentialOfferError);
+      // No secondary federation fetch for the rejected authorization server
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw CredentialOfferError when a non-inline authorization server is selected but the issuer declares none", async () => {
+      const federationPayload = {
+        exp: 1_700_003_600,
+        iat: 1_700_000_000,
+        iss: "https://issuer.example.it",
+        jwks: mockJwks,
+        metadata: {
+          oauth_authorization_server: authorizationServerMetadata,
+          // No authorization_servers declared on the credential issuer
+          openid_credential_issuer: credentialIssuerMetadata,
+        },
+        sub: "https://issuer.example.it",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        text: vi.fn().mockResolvedValue(buildFederationJwt(federationPayload)),
+      });
+
+      await expect(
+        fetchMetadata({
+          ...baseOptions,
+          authorizationServer: "https://other.example.it",
+        }),
+      ).rejects.toThrow(CredentialOfferError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/packages/oid4vci/src/metadata/fetch-metadata.ts
+++ b/packages/oid4vci/src/metadata/fetch-metadata.ts
@@ -167,18 +167,35 @@ async function tryFederationDiscovery(
 }
 
 /**
- * Applies the selected authorization server to a federation discovery result.
+ * Resolves the authorization server for a federation discovery result, following
+ * the IT-Wallet trust model (identical across v1.3 and v1.4).
  *
- * When `authorizationServer` is omitted, or matches the issuer of the
- * authorization server already attested inline in the Credential Issuer entity
- * statement, the result is returned unchanged (no secondary fetch).
+ * Per OID4VCI, each `authorization_servers` entry is an Authorization Server
+ * identifier, and a co-located Credential Issuer uses its own identifier as the
+ * Authorization Server identifier. The inline `oauth_authorization_server` is
+ * attested within the Credential Issuer's own entity statement, so it is trusted
+ * only as the issuer's own (co-located) authorization server — i.e. only when
+ * the selected server equals the `credential_issuer` identifier. Any other
+ * authorization server is resolved through its own federation trust chain.
  *
- * When `authorizationServer` differs, the authorization server metadata is
- * resolved through the federation trust chain of that entity. The grafted
- * metadata replaces `oauth_authorization_server`, and the resolved entity
- * statement is preserved under `authorization_server_federation_claims` so its
- * provenance remains auditable.
+ * Selection of the authorization server to use:
+ * - **Explicit (from the credential offer):** the offer's `authorization_server`
+ *   must be one of the issuer's declared `authorization_servers`.
+ * - **No selection, no `authorization_servers` declared:** the Credential Issuer
+ *   is its own Authorization Server (co-located); the inline metadata is used.
+ * - **No selection, `authorization_servers` declared:** the Credential Issuer
+ *   itself when it is one of the declared servers (co-located), otherwise the
+ *   first declared server. The spec leaves the multi-server, no-selection case
+ *   undefined; defaulting to the first declared server matches the OID4VCI
+ *   fallback path.
  *
+ * When an authorization server is resolved via federation, the grafted metadata
+ * replaces `oauth_authorization_server`, and the resolved entity statement is
+ * preserved under `authorization_server_federation_claims` so its provenance
+ * remains auditable.
+ *
+ * @throws {CredentialOfferError} If an authorization server selected from the
+ *   credential offer is not among the issuer's `authorization_servers`.
  * @throws {ValidationError} If the selected authorization server cannot be
  *   resolved via federation or does not expose oauth_authorization_server metadata.
  */
@@ -188,25 +205,43 @@ async function applyFederationAuthorizationServerSelection(
   authorizationServer?: string,
   verifyJwt?: VerifyJwtCallback,
 ): Promise<RawFederationResult> {
-  if (!authorizationServer) {
-    return federationResult;
+  const credentialIssuer =
+    federationResult.metadata?.openid_credential_issuer?.credential_issuer;
+  const authorizationServers =
+    federationResult.metadata?.openid_credential_issuer?.authorization_servers;
+
+  let selectedAuthorizationServer: string | undefined;
+
+  if (authorizationServer) {
+    // Explicit selection from the credential offer: it must be one of the
+    // declared authorization servers.
+    assertAuthorizationServerAllowed(authorizationServer, authorizationServers);
+    selectedAuthorizationServer = authorizationServer;
+  } else if (authorizationServers && authorizationServers.length > 0) {
+    // No selection from the offer: prefer the Credential Issuer itself when it
+    // is one of the declared servers (co-located), otherwise default to the
+    // first declared server.
+    selectedAuthorizationServer =
+      credentialIssuer && authorizationServers.includes(credentialIssuer)
+        ? credentialIssuer
+        : authorizationServers[0];
+  } else {
+    // No declared servers: the Credential Issuer is its own Authorization Server.
+    selectedAuthorizationServer = credentialIssuer;
   }
 
-  const inlineAuthorizationServer =
-    federationResult.metadata?.oauth_authorization_server;
-
-  if (inlineAuthorizationServer?.issuer === authorizationServer) {
+  // The inline authorization server is trusted only as the issuer's own
+  // (co-located) one; everything else is resolved via federation.
+  if (
+    !selectedAuthorizationServer ||
+    selectedAuthorizationServer === credentialIssuer
+  ) {
     return federationResult;
   }
-
-  assertAuthorizationServerAllowed(
-    authorizationServer,
-    federationResult.metadata?.openid_credential_issuer?.authorization_servers,
-  );
 
   const authorizationServerResult = await tryFederationDiscovery(
     fetch,
-    authorizationServer,
+    selectedAuthorizationServer,
     verifyJwt,
   );
 
@@ -215,7 +250,7 @@ async function applyFederationAuthorizationServerSelection(
 
   if (!resolvedAuthorizationServer) {
     throw new ValidationError(
-      `Federation discovery did not yield oauth_authorization_server metadata for authorization server '${authorizationServer}'`,
+      `Federation discovery did not yield oauth_authorization_server metadata for authorization server '${selectedAuthorizationServer}'`,
     );
   }
 

--- a/packages/oid4vci/src/metadata/fetch-metadata.ts
+++ b/packages/oid4vci/src/metadata/fetch-metadata.ts
@@ -14,6 +14,7 @@ import {
 } from "@pagopa/io-wallet-utils";
 import z from "zod";
 
+import { assertAuthorizationServerAllowed } from "../credential-offer/validate-credential-offer";
 import { CredentialOfferError, FetchMetadataError } from "../errors";
 import {
   MetadataResponse,
@@ -47,32 +48,6 @@ interface RawOid4vciResult {
 
 function ensureTrailingSlash(url: string): string {
   return url.endsWith("/") ? url : `${url}/`;
-}
-
-/**
- * Ensures an authorization server selected from a credential offer is one of the
- * `authorization_servers` declared by the Credential Issuer metadata.
- *
- * No-op when no authorization server was selected. This check mirrors (and runs
- * ahead of) the credential offer validation step, so a metadata fetch driven by
- * an offer fails fast on a mismatched authorization server.
- *
- * @throws {CredentialOfferError} If a selected authorization server is absent
- *   from (or unsupported by) the issuer's `authorization_servers` list.
- */
-function assertAuthorizationServerAllowed(
-  authorizationServer: string | undefined,
-  authorizationServers: readonly string[] | undefined,
-): void {
-  if (
-    authorizationServer &&
-    (!authorizationServers ||
-      !authorizationServers.includes(authorizationServer))
-  ) {
-    throw new CredentialOfferError(
-      "offer provided authorization server is not in the `authorization_servers` list defined by the issuer metadata",
-    );
-  }
 }
 
 export interface FetchMetadataOptions {
@@ -246,7 +221,9 @@ async function applyFederationAuthorizationServerSelection(
     !parsedSelectedAuthorizationServer.success ||
     !parsedSelectedAuthorizationServer.data.startsWith("https://")
   ) {
-    throw new ValidationError("selected authorization server is not a valid HTTPS URL");
+    throw new ValidationError(
+      "selected authorization server is not a valid HTTPS URL",
+    );
   }
 
   const authorizationServerResult = await tryFederationDiscovery(

--- a/packages/oid4vci/src/metadata/fetch-metadata.ts
+++ b/packages/oid4vci/src/metadata/fetch-metadata.ts
@@ -14,7 +14,7 @@ import {
 } from "@pagopa/io-wallet-utils";
 import z from "zod";
 
-import { FetchMetadataError } from "../errors";
+import { CredentialOfferError, FetchMetadataError } from "../errors";
 import {
   MetadataResponse,
   zMetadataResponseV1_0,
@@ -23,6 +23,15 @@ import {
 } from "./z-metadata-response";
 
 interface RawFederationResult {
+  /**
+   * Entity statement claims of the Authorization Server, present only when the
+   * selected authorization server was resolved through a federation entity
+   * distinct from the Credential Issuer. Preserves the AS metadata provenance
+   * so its trust chain remains auditable.
+   */
+  authorization_server_federation_claims?: z.infer<
+    typeof itWalletEntityStatementClaimsSchema
+  >;
   discoveredVia: "federation";
   metadata: z.infer<typeof itWalletEntityStatementClaimsSchema>["metadata"];
   openid_federation_claims: z.infer<typeof itWalletEntityStatementClaimsSchema>;
@@ -40,7 +49,40 @@ function ensureTrailingSlash(url: string): string {
   return url.endsWith("/") ? url : `${url}/`;
 }
 
+/**
+ * Ensures an authorization server selected from a credential offer is one of the
+ * `authorization_servers` declared by the Credential Issuer metadata.
+ *
+ * No-op when no authorization server was selected. This check mirrors (and runs
+ * ahead of) the credential offer validation step, so a metadata fetch driven by
+ * an offer fails fast on a mismatched authorization server.
+ *
+ * @throws {CredentialOfferError} If a selected authorization server is absent
+ *   from (or unsupported by) the issuer's `authorization_servers` list.
+ */
+function assertAuthorizationServerAllowed(
+  authorizationServer: string | undefined,
+  authorizationServers: readonly string[] | undefined,
+): void {
+  if (
+    authorizationServer &&
+    (!authorizationServers ||
+      !authorizationServers.includes(authorizationServer))
+  ) {
+    throw new CredentialOfferError(
+      "offer provided authorization server is not in the `authorization_servers` list defined by the issuer's config",
+    );
+  }
+}
+
 export interface FetchMetadataOptions {
+  /**
+   * Optional Authorization Server URL selected from a credential offer.
+   * When provided, it must be a valid HTTPS URL and exactly match one of
+   * the Credential Issuer metadata authorization_servers.
+   */
+  authorizationServer?: string;
+
   /** Callback providing the fetch implementation */
   callbacks: {
     /**
@@ -125,6 +167,70 @@ async function tryFederationDiscovery(
 }
 
 /**
+ * Applies the selected authorization server to a federation discovery result.
+ *
+ * When `authorizationServer` is omitted, or matches the issuer of the
+ * authorization server already attested inline in the Credential Issuer entity
+ * statement, the result is returned unchanged (no secondary fetch).
+ *
+ * When `authorizationServer` differs, the authorization server metadata is
+ * resolved through the federation trust chain of that entity. The grafted
+ * metadata replaces `oauth_authorization_server`, and the resolved entity
+ * statement is preserved under `authorization_server_federation_claims` so its
+ * provenance remains auditable.
+ *
+ * @throws {ValidationError} If the selected authorization server cannot be
+ *   resolved via federation or does not expose oauth_authorization_server metadata.
+ */
+async function applyFederationAuthorizationServerSelection(
+  fetch: ReturnType<typeof createFetcher>,
+  federationResult: RawFederationResult,
+  authorizationServer?: string,
+  verifyJwt?: VerifyJwtCallback,
+): Promise<RawFederationResult> {
+  if (!authorizationServer) {
+    return federationResult;
+  }
+
+  const inlineAuthorizationServer =
+    federationResult.metadata?.oauth_authorization_server;
+
+  if (inlineAuthorizationServer?.issuer === authorizationServer) {
+    return federationResult;
+  }
+
+  assertAuthorizationServerAllowed(
+    authorizationServer,
+    federationResult.metadata?.openid_credential_issuer?.authorization_servers,
+  );
+
+  const authorizationServerResult = await tryFederationDiscovery(
+    fetch,
+    authorizationServer,
+    verifyJwt,
+  );
+
+  const resolvedAuthorizationServer =
+    authorizationServerResult?.metadata?.oauth_authorization_server;
+
+  if (!resolvedAuthorizationServer) {
+    throw new ValidationError(
+      `Federation discovery did not yield oauth_authorization_server metadata for authorization server '${authorizationServer}'`,
+    );
+  }
+
+  return {
+    ...federationResult,
+    authorization_server_federation_claims:
+      authorizationServerResult.openid_federation_claims,
+    metadata: {
+      ...federationResult.metadata,
+      oauth_authorization_server: resolvedAuthorizationServer,
+    } as RawFederationResult["metadata"],
+  };
+}
+
+/**
  * Executes the fallback OID4VCI discovery path:
  *   1. GET {baseUrl}/.well-known/openid-credential-issuer
  *   2a. If authorization_servers[] is present → GET {authServerUrl}/.well-known/oauth-authorization-server
@@ -136,6 +242,7 @@ async function tryFederationDiscovery(
 async function fallbackDiscovery(
   fetch: ReturnType<typeof createFetcher>,
   baseUrl: string,
+  authorizationServer?: string,
 ): Promise<RawOid4vciResult> {
   const issuerUrl = new URL(
     ".well-known/openid-credential-issuer",
@@ -152,13 +259,17 @@ async function fallbackDiscovery(
   );
   const authorizationServers = issuerJson.authorization_servers;
 
+  assertAuthorizationServerAllowed(authorizationServer, authorizationServers);
+
   let oauthAuthorizationServer: Record<string, unknown>;
 
   if (authorizationServers && authorizationServers.length > 0) {
-    const parsedUrl = z.url().safeParse(authorizationServers[0]);
+    const selectedAuthorizationServer =
+      authorizationServer ?? authorizationServers[0];
+    const parsedUrl = z.url().safeParse(selectedAuthorizationServer);
     if (!parsedUrl.success || !parsedUrl.data.startsWith("https://")) {
       throw new ValidationError(
-        "authorization_servers[0] is not a valid HTTPS URL",
+        "selected authorization server is not a valid HTTPS URL",
       );
     }
 
@@ -217,9 +328,18 @@ async function fetchMetadataV1_3(
     options.credentialIssuerUrl,
     options.callbacks.verifyJwt,
   );
-  const raw =
-    federationResult ??
-    (await fallbackDiscovery(fetch, options.credentialIssuerUrl));
+  const raw = federationResult
+    ? await applyFederationAuthorizationServerSelection(
+        fetch,
+        federationResult,
+        options.authorizationServer,
+        options.callbacks.verifyJwt,
+      )
+    : await fallbackDiscovery(
+        fetch,
+        options.credentialIssuerUrl,
+        options.authorizationServer,
+      );
   return parseWithErrorHandling(
     zMetadataResponseV1_3,
     raw,
@@ -285,6 +405,7 @@ export async function fetchMetadata(
       error instanceof UnexpectedStatusCodeError ||
       error instanceof ValidationError ||
       error instanceof ItWalletSpecsVersionError ||
+      error instanceof CredentialOfferError ||
       error instanceof FetchMetadataError
     ) {
       throw error;

--- a/packages/oid4vci/src/metadata/fetch-metadata.ts
+++ b/packages/oid4vci/src/metadata/fetch-metadata.ts
@@ -70,7 +70,7 @@ function assertAuthorizationServerAllowed(
       !authorizationServers.includes(authorizationServer))
   ) {
     throw new CredentialOfferError(
-      "offer provided authorization server is not in the `authorization_servers` list defined by the issuer's config",
+      "offer provided authorization server is not in the `authorization_servers` list defined by the issuer metadata",
     );
   }
 }
@@ -239,9 +239,19 @@ async function applyFederationAuthorizationServerSelection(
     return federationResult;
   }
 
+  const parsedSelectedAuthorizationServer = z
+    .url()
+    .safeParse(selectedAuthorizationServer);
+  if (
+    !parsedSelectedAuthorizationServer.success ||
+    !parsedSelectedAuthorizationServer.data.startsWith("https://")
+  ) {
+    throw new ValidationError("selected authorization server is not a valid HTTPS URL");
+  }
+
   const authorizationServerResult = await tryFederationDiscovery(
     fetch,
-    selectedAuthorizationServer,
+    parsedSelectedAuthorizationServer.data,
     verifyJwt,
   );
 

--- a/packages/oid4vci/src/metadata/z-metadata-response.ts
+++ b/packages/oid4vci/src/metadata/z-metadata-response.ts
@@ -12,6 +12,13 @@ export const zMetadataResponseV1_0 = z.object({
 });
 
 export const zMetadataResponseV1_3 = z.object({
+  /**
+   * Entity statement claims of the Authorization Server, present only when the
+   * selected authorization server was resolved through a federation entity
+   * distinct from the Credential Issuer.
+   */
+  authorization_server_federation_claims:
+    itWalletEntityStatementClaimsSchema.optional(),
   discoveredVia: z.enum(["federation", "oid4vci"]),
   metadata: itWalletMetadataV1_3,
   openid_federation_claims: itWalletEntityStatementClaimsSchema.optional(),

--- a/packages/oid4vci/src/metadata/z-metadata-response.ts
+++ b/packages/oid4vci/src/metadata/z-metadata-response.ts
@@ -35,5 +35,5 @@ export type MetadataResponse = MetadataResponseV1_0 | MetadataResponseV1_3;
 
 // For intermediate parsing in fallbackDiscovery:
 export const zPartialIssuerMetadata = z.looseObject({
-  authorization_servers: z.array(z.string()).optional(),
+  authorization_servers: z.tuple([z.url()], z.url()).optional(),
 });


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR improves the SDK's conformance by introducing stricter checks for the received credential offers and improving metadata fetching by covering some more edge cases in the federation path and adding the capability to fetch credential offer suggested authorization server metadata.

#### List of Changes

<!--- Describe your changes in detail -->
- Add the `issuerState` optional field in `create-authorization-request.ts` in the `oauth2` package.
- add checks of the offer's `authorization_server` field according to the ITW specification.
- add support for ITW v1.4 credential offer,
- add the `authorization_server` field to fetch the metadata from the issuer-suggested server in case of a credential offer flow.
- improve the `fetchMetadata` federation path by making it fetch another OID-FED EC in case the `openid-credential-issuer.authorization_servers` is present and doesn't specify the issuer itself.


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The patch is needed for consumer apps to properly implement the credential offer flows without patching the native libraries.

Solves WLS-128.

#### How Has This Been Tested?

Unit tests have been added to test the new functionalities.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
