### PR TITLE
fix: mdoc credential_signing_alg_values_supported numeric values in SupportedCredentialMetadata V1.0

### DIFF
--- a/.changeset/eighty-mails-call.md
+++ b/.changeset/eighty-mails-call.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid-federation": patch
+---
+
+fix: mdoc credential_signing_alg_values_supported numeric values in SupportedCredentialMetadata V1.0

--- a/packages/oid-federation/src/metadata/entity/v1.0/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.0/itWalletCredentialIssuer.ts
@@ -28,12 +28,19 @@ export type SupportedCredentialMetadata = z.infer<
 
 export const SupportedCredentialMetadata = z.intersection(
   z.discriminatedUnion("format", [
-    z.object({ format: z.literal("dc+sd-jwt"), vct: z.string() }),
-    z.object({ doctype: z.string(), format: z.literal("mso_mdoc") }),
+    z.object({
+      credential_signing_alg_values_supported: z.array(z.string()),
+      format: z.literal("dc+sd-jwt"),
+      vct: z.string(),
+    }),
+    z.object({
+      credential_signing_alg_values_supported: z.array(z.number().int()),
+      doctype: z.string(),
+      format: z.literal("mso_mdoc"),
+    }),
   ]),
   z.object({
     claims: z.array(ClaimsMetadata),
-    credential_signing_alg_values_supported: z.array(z.string()),
     cryptographic_binding_methods_supported: z.array(z.string()),
     display: z.array(CredentialDisplayMetadata),
     proof_types_supported: z.object({


### PR DESCRIPTION
This pull request updates the `SupportedCredentialMetadata` type definition in `itWalletCredentialIssuer.ts` to ensure that the `credential_signing_alg_values_supported` property is explicitly defined for each credential format, and aligns its type with the expected value for each format.

**Type definition improvements:**

* For the `"dc+sd-jwt"` format, `credential_signing_alg_values_supported` is now required and must be an array of strings, ensuring correct typing and validation.
* For the `"mso_mdoc"` format, `credential_signing_alg_values_supported` is now required and must be an array of integers, matching the expected data structure for this format.
* The previously top-level `credential_signing_alg_values_supported` property is removed from the shared object, and is now format-specific, reducing ambiguity and improving type safety.