### PR TITLE
chore: adjustments to Credential Offer and fetchMetadata interfaces

### DIFF
--- a/.changeset/slow-berries-hope.md
+++ b/.changeset/slow-berries-hope.md
@@ -1,0 +1,7 @@
+---
+"@pagopa/io-wallet-oid4vci": patch
+---
+
+- Added scope?: never to ExtractGrantDetailsResultV1_4
+- Made credentialIssuerMetadata mandatory in BaseValidateCredentialOfferOptions
+- Removed inline substitution of oauth_authorization_servers with the one of the external authorizationServer in the issuer EC returned by fetchMetadata.

--- a/packages/oid4vci/src/credential-offer/__tests__/validate-credential-offer.test.ts
+++ b/packages/oid4vci/src/credential-offer/__tests__/validate-credential-offer.test.ts
@@ -44,6 +44,7 @@ describe("validateCredentialOffer", () => {
     it("should validate a valid credential offer", async () => {
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: validCredentialOffer,
       };
 
@@ -94,6 +95,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: multiConfigOffer,
       };
 
@@ -110,6 +112,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: invalidOffer,
       };
 
@@ -132,6 +135,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: invalidOffer,
       };
 
@@ -154,6 +158,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: invalidOffer,
       };
 
@@ -175,6 +180,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: invalidOffer,
       };
 
@@ -202,6 +208,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: invalidOffer,
       };
 
@@ -353,7 +360,7 @@ describe("validateCredentialOffer", () => {
       await expect(validateCredentialOffer(options)).resolves.toBeUndefined();
     });
 
-    it("should throw CredentialOfferError when authorization_server is present but no credentialIssuerMetadata is provided", async () => {
+    it("should throw CredentialOfferError when authorization_server is present but credentialIssuerMetadata has no authorization_servers", async () => {
       const offer: CredentialOfferV1_3 = {
         ...validCredentialOffer,
         grants: {
@@ -366,8 +373,8 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: offer,
-        // No credentialIssuerMetadata provided
       };
 
       await expect(validateCredentialOffer(options)).rejects.toThrow(
@@ -415,6 +422,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: offer,
       };
 
@@ -433,6 +441,7 @@ describe("validateCredentialOffer", () => {
 
       const options: ValidateCredentialOfferOptionsV1_3 = {
         config: v1_3Config,
+        credentialIssuerMetadata: {},
         credentialOffer: offer,
       };
 
@@ -454,6 +463,7 @@ describe("validateCredentialOffer", () => {
     it("should validate a v1.4 offer that carries no scope", async () => {
       const options: ValidateCredentialOfferOptionsV1_4 = {
         config: v1_4Config,
+        credentialIssuerMetadata: {},
         credentialOffer: validV1_4Offer,
       };
 
@@ -463,6 +473,7 @@ describe("validateCredentialOffer", () => {
     it("should validate a v1.4 offer with only the required fields", async () => {
       const options: ValidateCredentialOfferOptionsV1_4 = {
         config: v1_4Config,
+        credentialIssuerMetadata: {},
         credentialOffer: {
           credential_configuration_ids: ["UniversityDegree"],
           credential_issuer: "https://issuer.example.com",
@@ -478,6 +489,7 @@ describe("validateCredentialOffer", () => {
     it("should still enforce HTTPS credential_issuer for a v1.4 offer", async () => {
       const options: ValidateCredentialOfferOptionsV1_4 = {
         config: v1_4Config,
+        credentialIssuerMetadata: {},
         credentialOffer: {
           ...validV1_4Offer,
           credential_issuer: "http://issuer.example.com",
@@ -492,6 +504,7 @@ describe("validateCredentialOffer", () => {
     it("should report the v1.4 version label when grants is missing", async () => {
       const options: ValidateCredentialOfferOptionsV1_4 = {
         config: v1_4Config,
+        credentialIssuerMetadata: {},
         credentialOffer: {
           credential_configuration_ids: ["UniversityDegree"],
           credential_issuer: "https://issuer.example.com",

--- a/packages/oid4vci/src/credential-offer/types.ts
+++ b/packages/oid4vci/src/credential-offer/types.ts
@@ -124,7 +124,7 @@ interface BaseValidateCredentialOfferOptions {
    *   ]
    * };
    */
-  credentialIssuerMetadata?: {
+  credentialIssuerMetadata: {
     authorization_servers?: [string, ...string[]];
   };
 }
@@ -251,6 +251,13 @@ export interface ExtractGrantDetailsResultV1_4 {
      * OPTIONAL. Used to correlate the authorization request with the credential offer.
      */
     issuerState?: string;
+
+    /**
+     * Version 1.4 has dropped support for the scope field,
+     * But typescript inference might have trouble recognizing this fact
+     * in its union type, so this is needed
+     */
+    scope?: never;
   };
 
   /**

--- a/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
+++ b/packages/oid4vci/src/metadata/__tests__/fetch-metadata.test.ts
@@ -737,12 +737,27 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
       });
 
       expect(result.discoveredVia).toBe("federation");
+      // The issuer's inline oauth_authorization_server is retained; the selected
+      // server is surfaced only through authorization_server_federation_claims.
       expect(result.metadata.oauth_authorization_server?.issuer).toBe(
+        "https://auth.example.it",
+      );
+      // The selected authorization server's federation entity statement is
+      // present and carries its own well-formed claims.
+      const authorizationServerFederationClaims = (
+        result as MetadataResponseV1_3
+      ).authorization_server_federation_claims;
+      expect(authorizationServerFederationClaims).toBeDefined();
+      expect(authorizationServerFederationClaims?.iss).toBe(
         "https://as2.example.it",
       );
+      expect(authorizationServerFederationClaims?.sub).toBe(
+        "https://as2.example.it",
+      );
+      expect(authorizationServerFederationClaims?.jwks.keys).toHaveLength(1);
       expect(
-        (result as MetadataResponseV1_3).authorization_server_federation_claims
-          ?.iss,
+        authorizationServerFederationClaims?.metadata
+          ?.oauth_authorization_server?.issuer,
       ).toBe("https://as2.example.it");
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(mockFetch).toHaveBeenNthCalledWith(
@@ -854,8 +869,9 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
           iss: "https://issuer.example.it",
           jwks: mockJwks,
           metadata: {
-            // Inline block present but the issuer is not among the declared
-            // servers: it must be discarded.
+            // Inline block present and retained on the result even though the
+            // issuer is not among the declared servers; the selected server is
+            // resolved separately via federation.
             oauth_authorization_server: authorizationServerMetadata,
             openid_credential_issuer: {
               ...credentialIssuerMetadata,
@@ -896,8 +912,10 @@ describe("fetchMetadata - offer authorization server compatibility", () => {
         const result = await fetchMetadata(baseOptions);
 
         expect(result.discoveredVia).toBe("federation");
+        // The issuer's inline oauth_authorization_server is retained even when
+        // the selected server is resolved separately via federation.
         expect(result.metadata.oauth_authorization_server?.issuer).toBe(
-          "https://as2.example.it",
+          "https://auth.example.it",
         );
         expect(mockFetch).toHaveBeenCalledTimes(2);
         expect(mockFetch).toHaveBeenNthCalledWith(

--- a/packages/oid4vci/src/metadata/fetch-metadata.ts
+++ b/packages/oid4vci/src/metadata/fetch-metadata.ts
@@ -232,12 +232,9 @@ async function applyFederationAuthorizationServerSelection(
     verifyJwt,
   );
 
-  const resolvedAuthorizationServer =
-    authorizationServerResult?.metadata?.oauth_authorization_server;
-
-  if (!resolvedAuthorizationServer) {
+  if (!authorizationServerResult) {
     throw new ValidationError(
-      `Federation discovery did not yield oauth_authorization_server metadata for authorization server '${selectedAuthorizationServer}'`,
+      `Federation discovery did not yield OpenID Federation metadata for authorization server '${selectedAuthorizationServer}'`,
     );
   }
 
@@ -245,10 +242,6 @@ async function applyFederationAuthorizationServerSelection(
     ...federationResult,
     authorization_server_federation_claims:
       authorizationServerResult.openid_federation_claims,
-    metadata: {
-      ...federationResult.metadata,
-      oauth_authorization_server: resolvedAuthorizationServer,
-    } as RawFederationResult["metadata"],
   };
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR brings small corrections to the SDK's API.

#### List of Changes

<!--- Describe your changes in detail -->

- Added `scope?: never` to `ExtractGrantDetailsResultV1_4`
- Made `credentialIssuerMetadata` mandatory in `BaseValidateCredentialOfferOptions`
- Removed inline substitution of `oauth_authorization_servers` with the one of the external authorizationServer in the issuer EC returned by `fetchMetadata`.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Without this minor fixes SDK users would need some hard casts and tweaks to pass TS checks, solves WLS-136.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Aligned unit tests to the new changes.