### PR TITLE
Add v1.4 credential issuer metadata and validation tests

### DIFF
--- a/packages/oid-federation/src/index.ts
+++ b/packages/oid-federation/src/index.ts
@@ -66,6 +66,22 @@ export {
   itWalletSolutionEntityMetadata as itWalletSolutionEntityMetadataV1_3,
 } from "./metadata/entity/v1.3/itWalletSolution";
 export type { ItWalletSolutionEntityMetadata as ItWalletSolutionEntityMetadataV1_3 } from "./metadata/entity/v1.3/itWalletSolution";
+export {
+  itWalletCredentialIssuerIdentifier as itWalletCredentialIssuerIdentifierV1_4,
+  itWalletCredentialIssuerMetadata as itWalletCredentialIssuerMetadataV1_4,
+  zKeyStorageLevel as zKeyStorageLevelV1_4,
+} from "./metadata/entity/v1.4/itWalletCredentialIssuer";
+export type {
+  AuthenticSources as AuthenticSourcesV1_4,
+  ClaimDisplayMetadata as ClaimDisplayMetadataV1_4,
+  ClaimsMetadata as ClaimsMetadataV1_4,
+  CredentialDisplayMetadata as CredentialDisplayMetadataV1_4,
+  CredentialMetadata as CredentialMetadataV1_4,
+  ImageMetadata as ImageMetadataV1_4,
+  ItWalletCredentialIssuerMetadata as ItWalletCredentialIssuerMetadataV1_4,
+  KeyStorageLevel as KeyStorageLevelV1_4,
+  SupportedCredentialMetadata as SupportedCredentialMetadataV1_4,
+} from "./metadata/entity/v1.4/itWalletCredentialIssuer";
 export * from "./metadata/itWalletMetadata";
 export * from "./metadata/operator/metadata-merge-strategy";
 export type * from "./metadata/operator/metadata-operator";

--- a/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
@@ -172,9 +172,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
       },
     };
 
-    expect(() =>
-      itWalletCredentialIssuerMetadata.parse(withoutName),
-    ).toThrow();
+    expect(() => itWalletCredentialIssuerMetadata.parse(withoutName)).toThrow();
   });
 
   it("should reject name in ClaimDisplayMetadata (label is required in v1.4)", () => {
@@ -186,7 +184,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             claims: [
               {
-                display: [{ name: "Full Name", locale: "en-US" }],
+                display: [{ locale: "en-US", name: "Full Name" }],
                 path: ["name"],
               },
             ],

--- a/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
@@ -154,8 +154,8 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
     ).not.toThrow();
   });
 
-  it("should reject metadata missing both label and name in credential display", () => {
-    const withoutLabel = {
+  it("should reject metadata missing required name in credential display", () => {
+    const withoutName = {
       ...validMetadata,
       credential_configurations_supported: {
         TestCred: {
@@ -164,7 +164,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
             display: [
               {
                 locale: "en-US",
-                // label is required and missing
+                // name is required and missing
               },
             ],
           },
@@ -173,7 +173,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
     };
 
     expect(() =>
-      itWalletCredentialIssuerMetadata.parse(withoutLabel),
+      itWalletCredentialIssuerMetadata.parse(withoutName),
     ).toThrow();
   });
 

--- a/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
@@ -177,7 +177,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
     ).toThrow();
   });
 
-  it("should accept name in ClaimDisplayMetadata (unchanged from v1.3)", () => {
+  it("should reject name in ClaimDisplayMetadata (label is required in v1.4)", () => {
     const withClaimName = {
       ...validMetadata,
       credential_configurations_supported: {
@@ -186,7 +186,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             claims: [
               {
-                display: [{ label: "Full Name", locale: "en-US" }],
+                display: [{ name: "Full Name", locale: "en-US" }],
                 path: ["name"],
               },
             ],
@@ -197,7 +197,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
 
     expect(() =>
       itWalletCredentialIssuerMetadata.parse(withClaimName),
-    ).not.toThrow();
+    ).toThrow();
   });
 
   it("should validate mso_mdoc format credential", () => {

--- a/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
@@ -23,7 +23,7 @@ const validMetadata: ItWalletCredentialIssuerMetadata = {
               {
                 description: "Full name of the degree holder",
                 locale: "en-US",
-                name: "Full Name",
+                label: "Full Name",
               },
             ],
             mandatory: true,
@@ -39,7 +39,7 @@ const validMetadata: ItWalletCredentialIssuerMetadata = {
               "uri#integrity": "sha256-...",
             },
             description: "University degree credential",
-            label: "University Degree",
+            name: "University Degree",
             locale: "en-US",
             logo: {
               alt_text: "University logo",
@@ -76,7 +76,7 @@ const validMetadata: ItWalletCredentialIssuerMetadata = {
     "https://issuer.example.com/credential_deferred",
   display: [
     {
-      label: "Example University",
+      name: "Example University",
       locale: "en-US",
     },
   ],
@@ -115,7 +115,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             display: [
               {
-                label: "Simple Credential",
+                name: "Simple Credential",
                 locale: "en-US",
               },
             ],
@@ -154,29 +154,6 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
     ).not.toThrow();
   });
 
-  it("should reject metadata with name instead of label in credential display", () => {
-    const withNameInDisplay = {
-      ...validMetadata,
-      credential_configurations_supported: {
-        TestCred: {
-          ...validMetadata.credential_configurations_supported.UniversityDegree,
-          credential_metadata: {
-            display: [
-              {
-                locale: "en-US",
-                name: "University Degree", // name is not valid in v1.4 CredentialDisplayMetadata
-              },
-            ],
-          },
-        },
-      },
-    };
-
-    expect(() =>
-      itWalletCredentialIssuerMetadata.parse(withNameInDisplay),
-    ).toThrow();
-  });
-
   it("should reject metadata missing both label and name in credential display", () => {
     const withoutLabel = {
       ...validMetadata,
@@ -209,7 +186,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             claims: [
               {
-                display: [{ locale: "en-US", name: "Full Name" }],
+                display: [{ locale: "en-US", label: "Full Name" }],
                 path: ["name"],
               },
             ],
@@ -235,7 +212,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             display: [
               {
-                label: "Mobile Driving License",
+                name: "Mobile Driving License",
                 locale: "en-US",
               },
             ],

--- a/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ItWalletCredentialIssuerMetadata,
+  itWalletCredentialIssuerMetadata,
+} from "../itWalletCredentialIssuer";
+
+const validMetadata: ItWalletCredentialIssuerMetadata = {
+  authorization_servers: ["https://auth.example.com"],
+  batch_credential_issuance: {
+    batch_size: 10,
+  },
+  credential_configurations_supported: {
+    UniversityDegree: {
+      authentic_sources: {
+        dataset_id: "university_degrees",
+        entity_id: "https://university.example.com",
+      },
+      credential_metadata: {
+        claims: [
+          {
+            display: [
+              {
+                description: "Full name of the degree holder",
+                locale: "en-US",
+                name: "Full Name",
+              },
+            ],
+            mandatory: true,
+            path: ["credentialSubject", "name"],
+            sd: "never",
+          },
+        ],
+        display: [
+          {
+            background_color: "#12107c",
+            background_image: {
+              uri: "https://issuer.example.org/bg.svg",
+              "uri#integrity": "sha256-...",
+            },
+            description: "University degree credential",
+            label: "University Degree",
+            locale: "en-US",
+            logo: {
+              alt_text: "University logo",
+              uri: "https://issuer.example.org/logo.svg",
+              "uri#integrity": "sha256-...",
+            },
+            watermark_image: {
+              uri: "https://issuer.example.org/watermark.svg",
+              "uri#integrity": "sha256-...",
+            },
+          },
+        ],
+      },
+      credential_signing_alg_values_supported: ["ES256"],
+      cryptographic_binding_methods_supported: ["jwk"],
+      format: "dc+sd-jwt",
+      proof_types_supported: {
+        jwt: {
+          key_attestations_required: {
+            key_storage: ["iso_18045_high"],
+            user_authentication: ["iso_18045_high"],
+          },
+          proof_signing_alg_values_supported: ["ES256"],
+        },
+      },
+      schema_id: "https://schema.example.org/UniversityDegree.json",
+      scope: "UniversityDegree",
+      vct: "UniversityDegree",
+    },
+  },
+  credential_endpoint: "https://issuer.example.com/credential",
+  credential_issuer: "https://issuer.example.com",
+  deferred_credential_endpoint:
+    "https://issuer.example.com/credential_deferred",
+  display: [
+    {
+      label: "Example University",
+      locale: "en-US",
+    },
+  ],
+  jwks: {
+    keys: [
+      {
+        crv: "P-256",
+        kid: "key-1",
+        kty: "EC",
+        x: "...",
+        y: "...",
+      },
+    ],
+  },
+  nonce_endpoint: "https://issuer.example.com/nonce",
+  notification_endpoint: "https://issuer.example.com/notification",
+  status_list_aggregation_endpoint: "https://issuer.example.com/status-list",
+  trust_frameworks_supported: ["it_wallet"],
+};
+
+describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
+  it("should validate complete v1.4 metadata with label field", () => {
+    expect(() =>
+      itWalletCredentialIssuerMetadata.parse(validMetadata),
+    ).not.toThrow();
+  });
+
+  it("should validate metadata with optional fields omitted", () => {
+    const minimalMetadata: ItWalletCredentialIssuerMetadata = {
+      credential_configurations_supported: {
+        SimpleCred: {
+          authentic_sources: {
+            dataset_id: "simple",
+            entity_id: "https://simple.example.com",
+          },
+          credential_metadata: {
+            display: [
+              {
+                label: "Simple Credential",
+                locale: "en-US",
+              },
+            ],
+          },
+          credential_signing_alg_values_supported: ["ES256"],
+          cryptographic_binding_methods_supported: ["jwk"],
+          format: "dc+sd-jwt",
+          proof_types_supported: {
+            jwt: {
+              proof_signing_alg_values_supported: ["ES256"],
+            },
+          },
+          schema_id: "https://schema.example.org/Simple.json",
+          scope: "SimpleCred",
+          vct: "SimpleCred",
+        },
+      },
+      credential_endpoint: "https://issuer.example.com/credential",
+      credential_issuer: "https://issuer.example.com",
+      jwks: {
+        keys: [
+          {
+            crv: "P-256",
+            kid: "key-1",
+            kty: "EC",
+            x: "...",
+            y: "...",
+          },
+        ],
+      },
+      trust_frameworks_supported: ["it_wallet"],
+    };
+
+    expect(() =>
+      itWalletCredentialIssuerMetadata.parse(minimalMetadata),
+    ).not.toThrow();
+  });
+
+  it("should reject metadata with name instead of label in credential display", () => {
+    const withNameInDisplay = {
+      ...validMetadata,
+      credential_configurations_supported: {
+        TestCred: {
+          ...validMetadata.credential_configurations_supported.UniversityDegree,
+          credential_metadata: {
+            display: [
+              {
+                locale: "en-US",
+                name: "University Degree", // name is not valid in v1.4 CredentialDisplayMetadata
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      itWalletCredentialIssuerMetadata.parse(withNameInDisplay),
+    ).toThrow();
+  });
+
+  it("should reject metadata missing both label and name in credential display", () => {
+    const withoutLabel = {
+      ...validMetadata,
+      credential_configurations_supported: {
+        TestCred: {
+          ...validMetadata.credential_configurations_supported.UniversityDegree,
+          credential_metadata: {
+            display: [
+              {
+                locale: "en-US",
+                // label is required and missing
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      itWalletCredentialIssuerMetadata.parse(withoutLabel),
+    ).toThrow();
+  });
+
+  it("should accept name in ClaimDisplayMetadata (unchanged from v1.3)", () => {
+    const withClaimName = {
+      ...validMetadata,
+      credential_configurations_supported: {
+        TestCred: {
+          ...validMetadata.credential_configurations_supported.UniversityDegree,
+          credential_metadata: {
+            claims: [
+              {
+                display: [{ locale: "en-US", name: "Full Name" }],
+                path: ["name"],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      itWalletCredentialIssuerMetadata.parse(withClaimName),
+    ).not.toThrow();
+  });
+
+  it("should validate mso_mdoc format credential", () => {
+    const msoMdocMetadata = {
+      ...validMetadata,
+      credential_configurations_supported: {
+        mDL: {
+          authentic_sources: {
+            dataset_id: "driving_licenses",
+            entity_id: "https://dmv.example.gov",
+          },
+          credential_metadata: {
+            display: [
+              {
+                label: "Mobile Driving License",
+                locale: "en-US",
+              },
+            ],
+          },
+          credential_signing_alg_values_supported: [-7],
+          cryptographic_binding_methods_supported: ["cose_key"],
+          doctype: "org.iso.18013.5.1.mDL",
+          format: "mso_mdoc",
+          proof_types_supported: {
+            jwt: {
+              proof_signing_alg_values_supported: ["ES256"],
+            },
+          },
+          schema_id: "https://schema.example.org/mDL.json",
+          scope: "mDL",
+        },
+      },
+    };
+
+    expect(() =>
+      itWalletCredentialIssuerMetadata.parse(msoMdocMetadata),
+    ).not.toThrow();
+  });
+});

--- a/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/__tests__/itWalletCredentialIssuer.test.ts
@@ -22,8 +22,8 @@ const validMetadata: ItWalletCredentialIssuerMetadata = {
             display: [
               {
                 description: "Full name of the degree holder",
-                locale: "en-US",
                 label: "Full Name",
+                locale: "en-US",
               },
             ],
             mandatory: true,
@@ -39,13 +39,13 @@ const validMetadata: ItWalletCredentialIssuerMetadata = {
               "uri#integrity": "sha256-...",
             },
             description: "University degree credential",
-            name: "University Degree",
             locale: "en-US",
             logo: {
               alt_text: "University logo",
               uri: "https://issuer.example.org/logo.svg",
               "uri#integrity": "sha256-...",
             },
+            name: "University Degree",
             watermark_image: {
               uri: "https://issuer.example.org/watermark.svg",
               "uri#integrity": "sha256-...",
@@ -76,8 +76,8 @@ const validMetadata: ItWalletCredentialIssuerMetadata = {
     "https://issuer.example.com/credential_deferred",
   display: [
     {
-      name: "Example University",
       locale: "en-US",
+      name: "Example University",
     },
   ],
   jwks: {
@@ -115,8 +115,8 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             display: [
               {
-                name: "Simple Credential",
                 locale: "en-US",
+                name: "Simple Credential",
               },
             ],
           },
@@ -186,7 +186,7 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             claims: [
               {
-                display: [{ locale: "en-US", label: "Full Name" }],
+                display: [{ label: "Full Name", locale: "en-US" }],
                 path: ["name"],
               },
             ],
@@ -212,8 +212,8 @@ describe("itWalletCredentialIssuerMetadata v1.4 metadata", () => {
           credential_metadata: {
             display: [
               {
-                name: "Mobile Driving License",
                 locale: "en-US",
+                name: "Mobile Driving License",
               },
             ],
           },

--- a/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+
+import { jsonWebKeySetSchema } from "../../../jwk/jwk";
+
+export type ImageMetadata = z.infer<typeof ImageMetadata>;
+export const ImageMetadata = z.object({
+  alt_text: z.string().optional(),
+  uri: z.url(),
+  "uri#integrity": z.string().optional(),
+});
+
+export type CredentialDisplayMetadata = z.infer<
+  typeof CredentialDisplayMetadata
+>;
+
+export const CredentialDisplayMetadata = z.object({
+  background_color: z.string().optional(),
+  background_image: ImageMetadata.optional(),
+  description: z.string().optional(),
+  label: z.string(),
+  locale: z.string(),
+  logo: ImageMetadata.optional(),
+  watermark_image: ImageMetadata.optional(),
+});
+
+export type ClaimDisplayMetadata = z.infer<typeof ClaimDisplayMetadata>;
+export const ClaimDisplayMetadata = z.object({
+  description: z.string().optional(),
+  locale: z.string(),
+  name: z.string(),
+});
+
+export type ClaimsMetadata = z.infer<typeof ClaimsMetadata>;
+export const ClaimsMetadata = z.object({
+  display: z.array(ClaimDisplayMetadata).optional(),
+  mandatory: z.boolean().optional(),
+  path: z.array(z.union([z.string(), z.number(), z.null()])),
+  sd: z.enum(["always", "never"]).optional(),
+});
+
+export type CredentialMetadata = z.infer<typeof CredentialMetadata>;
+export const CredentialMetadata = z.object({
+  claims: z.array(ClaimsMetadata).optional(),
+  display: z.array(CredentialDisplayMetadata).optional(),
+});
+
+export const zKeyStorageLevel = z.enum([
+  "iso_18045_high",
+  "iso_18045_moderate",
+  "iso_18045_enhanced-basic",
+  "iso_18045_basic",
+]);
+
+export type KeyStorageLevel = z.infer<typeof zKeyStorageLevel>;
+
+export const zUserAuthenticationLevel = zKeyStorageLevel;
+export type UserAuthenticationLevel = KeyStorageLevel;
+
+export type ProofTypesSupported = z.infer<typeof ProofTypesSupported>;
+export const ProofTypesSupported = z.object({
+  jwt: z.object({
+    key_attestations_required: z
+      .object({
+        key_storage: z.array(zKeyStorageLevel).min(1).optional(),
+        user_authentication: z
+          .array(zUserAuthenticationLevel)
+          .min(1)
+          .optional(),
+      })
+      .optional(),
+    proof_signing_alg_values_supported: z.array(z.string()),
+  }),
+});
+
+export type AuthenticSources = z.infer<typeof AuthenticSources>;
+export const AuthenticSources = z.object({
+  dataset_id: z.string(),
+  entity_id: z.string(),
+});
+
+export type SupportedCredentialMetadata = z.infer<
+  typeof SupportedCredentialMetadata
+>;
+
+export const SupportedCredentialMetadata = z.intersection(
+  z.discriminatedUnion("format", [
+    z.object({
+      credential_signing_alg_values_supported: z.array(z.string()),
+      format: z.literal("dc+sd-jwt"),
+      vct: z.string(),
+    }),
+    z.object({
+      credential_signing_alg_values_supported: z.array(z.number().int()),
+      doctype: z.string(),
+      format: z.literal("mso_mdoc"),
+    }),
+  ]),
+  z.object({
+    authentic_sources: AuthenticSources,
+    credential_metadata: CredentialMetadata,
+    cryptographic_binding_methods_supported: z.array(z.string()),
+    proof_types_supported: ProofTypesSupported,
+    schema_id: z.string(),
+    scope: z.string(),
+  }),
+);
+
+/**
+ * IT Wallet Credential Issuer Metadata for v1.4 specification
+ *
+ * Changes from v1.3:
+ * - MODIFIED: CredentialDisplayMetadata uses `label` instead of `name` (IETF draft-ietf-oauth-sd-jwt-vc-12 §claim-display-metadata)
+ *
+ * {@link https://italia.github.io/eid-wallet-it-docs/releases/1.4.0/en/credential-issuer-solution.html#metadata-for-openid-credential-issuer}
+ */
+export const itWalletCredentialIssuerMetadata = z.looseObject({
+  authorization_servers: z.tuple([z.url()], z.url()).optional(),
+  batch_credential_issuance: z
+    .object({
+      batch_size: z.number().int().positive(),
+    })
+    .optional(),
+  credential_configurations_supported: z.record(
+    z.string(),
+    SupportedCredentialMetadata,
+  ),
+  credential_endpoint: z.url(),
+  credential_issuer: z.url(),
+  deferred_credential_endpoint: z.url().optional(),
+  display: z.array(CredentialDisplayMetadata).optional(),
+  jwks: jsonWebKeySetSchema,
+  nonce_endpoint: z.url().optional(),
+  notification_endpoint: z.url().optional(),
+  status_list_aggregation_endpoint: z.url().optional(),
+  trust_frameworks_supported: z.array(
+    z.union([
+      z.literal("eudi_wallet"),
+      z.literal("it_cie"),
+      z.literal("it_wallet"),
+      z.literal("it_l2+document_proof"),
+      /** @deprecated For backward compatibility only, will be removed in future versions. */
+      z.literal("it_spid"),
+    ]),
+  ),
+});
+
+export type ItWalletCredentialIssuerMetadata = z.input<
+  typeof itWalletCredentialIssuerMetadata
+>;
+
+export const itWalletCredentialIssuerIdentifier = "openid_credential_issuer";

--- a/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
@@ -109,7 +109,7 @@ export const SupportedCredentialMetadata = z.intersection(
  * IT Wallet Credential Issuer Metadata for v1.4 specification
  *
  * Changes from v1.3:
- * - MODIFIED: CredentialDisplayMetadata uses `label` instead of `name` (IETF draft-ietf-oauth-sd-jwt-vc-12 §claim-display-metadata)
+ * - MODIFIED: ClaimDisplayMetadata uses `label` instead of `name` (IETF draft-ietf-oauth-sd-jwt-vc-12 §claim-display-metadata)
  *
  * {@link https://italia.github.io/eid-wallet-it-docs/releases/1.4.0/en/credential-issuer-solution.html#metadata-for-openid-credential-issuer}
  */

--- a/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
@@ -17,7 +17,7 @@ export const CredentialDisplayMetadata = z.object({
   background_color: z.string().optional(),
   background_image: ImageMetadata.optional(),
   description: z.string().optional(),
-  label: z.string(),
+  name: z.string(),
   locale: z.string(),
   logo: ImageMetadata.optional(),
   watermark_image: ImageMetadata.optional(),
@@ -27,7 +27,7 @@ export type ClaimDisplayMetadata = z.infer<typeof ClaimDisplayMetadata>;
 export const ClaimDisplayMetadata = z.object({
   description: z.string().optional(),
   locale: z.string(),
-  name: z.string(),
+  label: z.string(),
 });
 
 export type ClaimsMetadata = z.infer<typeof ClaimsMetadata>;

--- a/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/itWalletCredentialIssuer.ts
@@ -17,17 +17,17 @@ export const CredentialDisplayMetadata = z.object({
   background_color: z.string().optional(),
   background_image: ImageMetadata.optional(),
   description: z.string().optional(),
-  name: z.string(),
   locale: z.string(),
   logo: ImageMetadata.optional(),
+  name: z.string(),
   watermark_image: ImageMetadata.optional(),
 });
 
 export type ClaimDisplayMetadata = z.infer<typeof ClaimDisplayMetadata>;
 export const ClaimDisplayMetadata = z.object({
   description: z.string().optional(),
-  locale: z.string(),
   label: z.string(),
+  locale: z.string(),
 });
 
 export type ClaimsMetadata = z.infer<typeof ClaimsMetadata>;

--- a/packages/oid-federation/src/metadata/itWalletMetadata.ts
+++ b/packages/oid-federation/src/metadata/itWalletMetadata.ts
@@ -41,6 +41,10 @@ import {
   itWalletSolutionEntityIdentifier as itWalletSolutionEntityIdentifierV1_3,
   itWalletSolutionEntityMetadata as itWalletSolutionEntityMetadataV1_3,
 } from "./entity/v1.3/itWalletSolution";
+import {
+  itWalletCredentialIssuerIdentifier as itWalletCredentialIssuerIdentifierV1_4,
+  itWalletCredentialIssuerMetadata as itWalletCredentialIssuerMetadataV1_4,
+} from "./entity/v1.4/itWalletCredentialIssuer";
 
 // v1.0 combined metadata
 export const itWalletMetadataV1_0 = z.strictObject({
@@ -69,21 +73,42 @@ export const itWalletMetadataV1_3 = z.strictObject({
     itWalletSolutionEntityMetadataV1_3.optional(),
 });
 
+// v1.4 combined metadata — uses v1.4 credential issuer schema (label replaces name in CredentialDisplayMetadata)
+export const itWalletMetadataV1_4 = z.strictObject({
+  [itWalletAuthorizationServerIdentifierV1_3]:
+    itWalletAuthorizationServerMetadataV1_3.optional(),
+  [itWalletCredentialIssuerIdentifierV1_4]:
+    itWalletCredentialIssuerMetadataV1_4.optional(),
+  [itWalletCredentialVerifierIdentifierV1_3]:
+    itWalletCredentialVerifierMetadataV1_3.optional(),
+  [itWalletFederationEntityIdentifier]:
+    itWalletFederationEntityMetadata.optional(),
+  [itWalletSolutionEntityIdentifierV1_3]:
+    itWalletSolutionEntityMetadataV1_3.optional(),
+});
+
 // Union — used by entity statement / entity configuration claims
-// v1.3 is tried first so that v1.3-specific fields are preserved during parsing
-export const itWalletMetadataSchema =
-  itWalletMetadataV1_3.or(itWalletMetadataV1_0);
+// v1.4 is tried first (most specific), then v1.3, then v1.0
+export const itWalletMetadataSchema = itWalletMetadataV1_4
+  .or(itWalletMetadataV1_3)
+  .or(itWalletMetadataV1_0);
 
 export type ItWalletMetadataV1_0 = z.output<typeof itWalletMetadataV1_0>;
 export type ItWalletMetadataV1_3 = z.output<typeof itWalletMetadataV1_3>;
-export type ItWalletMetadata = ItWalletMetadataV1_0 | ItWalletMetadataV1_3;
+export type ItWalletMetadataV1_4 = z.output<typeof itWalletMetadataV1_4>;
+export type ItWalletMetadata =
+  | ItWalletMetadataV1_0
+  | ItWalletMetadataV1_3
+  | ItWalletMetadataV1_4;
 
 export type ItWalletMetadataByVersion<V extends ItWalletSpecsVersion> =
   V extends ItWalletSpecsVersion.V1_0
     ? ItWalletMetadataV1_0
-    : V extends ItWalletSpecsVersion.V1_3 | ItWalletSpecsVersion.V1_4
+    : V extends ItWalletSpecsVersion.V1_3
       ? ItWalletMetadataV1_3
-      : never;
+      : V extends ItWalletSpecsVersion.V1_4
+        ? ItWalletMetadataV1_4
+        : never;
 
 /**
  * Checks whether a metadata object matches the schema for a specific IT-Wallet version.
@@ -103,7 +128,7 @@ export function isItWalletMetadataVersion<V extends ItWalletSpecsVersion>(
     [ItWalletSpecsVersion.V1_3]: () =>
       itWalletMetadataV1_3.safeParse(metadata).success,
     [ItWalletSpecsVersion.V1_4]: () =>
-      itWalletMetadataV1_3.safeParse(metadata).success,
+      itWalletMetadataV1_4.safeParse(metadata).success,
   });
 }
 
@@ -135,7 +160,7 @@ export function parseItWalletMetadataForVersion<V extends ItWalletSpecsVersion>(
       ),
     [ItWalletSpecsVersion.V1_4]: () =>
       parseWithErrorHandling(
-        itWalletMetadataV1_3,
+        itWalletMetadataV1_4,
         metadata,
         "invalid v1.4 metadata provided",
       ),

--- a/packages/oid-federation/src/metadata/itWalletMetadata.ts
+++ b/packages/oid-federation/src/metadata/itWalletMetadata.ts
@@ -73,7 +73,7 @@ export const itWalletMetadataV1_3 = z.strictObject({
     itWalletSolutionEntityMetadataV1_3.optional(),
 });
 
-// v1.4 combined metadata — uses v1.4 credential issuer schema (label replaces name in CredentialDisplayMetadata)
+// v1.4 combined metadata — uses v1.4 credential issuer schema (ClaimDisplayMetadata: label replaces name)
 export const itWalletMetadataV1_4 = z.strictObject({
   [itWalletAuthorizationServerIdentifierV1_3]:
     itWalletAuthorizationServerMetadataV1_3.optional(),


### PR DESCRIPTION
#### List of Changes
- Introduced v1.4 credential issuer metadata, including new schemas for `ClaimDisplayMetadata`.
- Renamed claim `name` in `label` in `ClaimDisplayMetadata` for consistency.

#### Motivation and Context
These changes implement the v1.4 specification for credential issuer metadata, addressing inconsistencies in property naming and structure from the previous version. This update ensures compliance with the latest standards and improves the overall usability of the metadata.

#### How Has This Been Tested?
Validation tests have been added to ensure the new metadata structures function correctly. Testing was conducted in a controlled environment to verify that the changes do not introduce regressions in existing functionality.

