### PR TITLE
feat(oid4vci): Add InvalidDpopProofError for handling invalid DPoP proof headers

### DIFF
--- a/.changeset/free-spoons-wonder.md
+++ b/.changeset/free-spoons-wonder.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid4vci": patch
+---
+
+feat(oid4vci): Add InvalidDpopProofError for handling invalid DPoP proof headers

--- a/packages/oid4vci/src/credential-request/__tests__/parse-credential-request.test.ts
+++ b/packages/oid4vci/src/credential-request/__tests__/parse-credential-request.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   CredentialAuthorizationHeaderError,
+  InvalidDpopProofError,
   MissingDpopProofError,
 } from "../../errors";
 import {
@@ -267,7 +268,7 @@ describe("parseCredentialRequest", () => {
     ).rejects.toThrow(MissingDpopProofError);
   });
 
-  it("throws MissingDpopProofError when DPoP header value is not a valid JWT", async () => {
+  it("throws InvalidDpopProofError when DPoP header value is not a valid JWT", async () => {
     const config = new IoWalletSdkConfig({
       itWalletSpecsVersion: ItWalletSpecsVersion.V1_0,
     });
@@ -287,7 +288,7 @@ describe("parseCredentialRequest", () => {
           dpop: "not-a-jwt",
         }),
       }),
-    ).rejects.toThrow(MissingDpopProofError);
+    ).rejects.toThrow(InvalidDpopProofError);
   });
 
   it("throws CredentialAuthorizationHeaderError when Authorization header is absent", async () => {

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -19,7 +19,8 @@ import {
 
 import {
   CredentialAuthorizationHeaderError,
-  MissingDpopProofError as CredentialDpopProofError,
+  InvalidDpopProofError,
+  MissingDpopProofError,
   ParseCredentialRequestError,
 } from "../errors";
 import {
@@ -277,7 +278,7 @@ async function validateProofJwkUniqueness(options: {
   const uniqueThumbprints = new Set(thumbprints);
 
   if (uniqueThumbprints.size !== thumbprints.length) {
-    throw new ValidationError(
+    throw new InvalidDpopProofError(
       "Credential request proofs must use unique jwk header values",
     );
   }
@@ -402,15 +403,13 @@ function parseDpopProof(headers: FetchHeaders): string {
   const extracted = extractDpopJwtFromHeaders(headers);
 
   if (!extracted.valid) {
-    throw new CredentialDpopProofError(
+    throw new InvalidDpopProofError(
       "Credential request contains a 'DPoP' header, but the value is not a valid JWT format",
     );
   }
 
   if (!extracted.dpopJwt) {
-    throw new CredentialDpopProofError(
-      "Credential request contains a 'DPoP' header, but the value is missing or empty",
-    );
+    throw new MissingDpopProofError();
   }
 
   return extracted.dpopJwt;
@@ -519,7 +518,8 @@ const dispatchParseCredentialRequest = createVersionDispatcher<
  * @param options - Parsing options and validation context.
  * @returns Promise resolving to the normalized parsed credential request including the extracted `accessToken` and `dpopProof`.
  * @throws {CredentialAuthorizationHeaderError} If the `Authorization` header is absent or invalid.
- * @throws {CredentialDpopProofError} If the `DPoP` header is absent or not a valid compact JWT.
+ * @throws {MissingDpopProofError} If the `DPoP` header is absent.
+ * @throws {InvalidDpopProofError} If the `DPoP` header is present but not a valid compact JWT.
  * @throws {ValidationError} If request body schema or semantic checks fail.
  * @throws {Oauth2JwtParseError} If a proof JWT cannot be decoded.
  * @throws {ParseCredentialRequestError} For unexpected parsing failures.
@@ -547,7 +547,8 @@ export async function parseCredentialRequest(
       error instanceof Oauth2JwtParseError ||
       error instanceof ValidationError ||
       error instanceof CredentialAuthorizationHeaderError ||
-      error instanceof CredentialDpopProofError
+      error instanceof MissingDpopProofError ||
+      error instanceof InvalidDpopProofError
     ) {
       throw error;
     }

--- a/packages/oid4vci/src/credential-request/parse-credential-request.ts
+++ b/packages/oid4vci/src/credential-request/parse-credential-request.ts
@@ -278,7 +278,7 @@ async function validateProofJwkUniqueness(options: {
   const uniqueThumbprints = new Set(thumbprints);
 
   if (uniqueThumbprints.size !== thumbprints.length) {
-    throw new InvalidDpopProofError(
+    throw new ValidationError(
       "Credential request proofs must use unique jwk header values",
     );
   }

--- a/packages/oid4vci/src/errors.ts
+++ b/packages/oid4vci/src/errors.ts
@@ -129,6 +129,19 @@ export class MissingDpopProofError extends Oid4vciError {
 }
 
 /**
+ * Error thrown when a credential request has an invalid DPoP proof header.
+ */
+export class InvalidDpopProofError extends Oid4vciError {
+  constructor(
+    message = "Credential request has an invalid 'DPoP' proof header",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "InvalidDpopProofError";
+  }
+}
+
+/**
  * Error thrown when a credential request has a missing or invalid Authorization header.
  */
 export class CredentialAuthorizationHeaderError extends Oid4vciError {


### PR DESCRIPTION
#### List of Changes
- Introduced `InvalidDpopProofError` to handle cases where the DPoP proof header is invalid.
- Updated relevant tests to throw `InvalidDpopProofError` instead of `MissingDpopProofError` when the DPoP header value is not a valid JWT.
- Adjusted documentation to reflect the new error handling.

#### Motivation and Context
This change improves error handling for credential requests by clearly distinguishing between missing and invalid DPoP proof headers. It enhances the robustness of the application by providing more specific error messages, which aids in debugging and user feedback.

#### How Has This Been Tested?
Changes have been tested using existing unit tests, which were updated to ensure that the new error handling is correctly implemented. The testing environment includes the latest version of the Vitest framework, and all tests passed successfully after modifications.

