### PR TITLE
fix: replace bare `workspace:` with `workspace:*` for correct npm publish resolution

### DIFF
--- a/.changeset/odd-taxis-remain.md
+++ b/.changeset/odd-taxis-remain.md
@@ -1,0 +1,6 @@
+---
+"@pagopa/io-wallet-oid-federation": patch
+"@pagopa/io-wallet-oid4vp": patch
+---
+
+fix: replace bare workspace: with workspace:\* for correct npm publish resolution

--- a/packages/oid-federation/package.json
+++ b/packages/oid-federation/package.json
@@ -29,7 +29,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts --sourcemap"
   },
   "dependencies": {
-    "@pagopa/io-wallet-utils": "workspace:",
+    "@pagopa/io-wallet-utils": "workspace:*",
     "buffer": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/oid4vp/package.json
+++ b/packages/oid4vp/package.json
@@ -33,10 +33,10 @@
     "@openid4vc/oauth2": "catalog:",
     "@openid4vc/utils": "catalog:",
     "@openid4vc/openid4vp": "catalog:",
-    "zod": "catalog:",
-    "@pagopa/io-wallet-utils": "workspace:",
-    "@pagopa/io-wallet-oauth2": "workspace:",
-    "@pagopa/io-wallet-oid-federation": "workspace:"
+    "@pagopa/io-wallet-oid-federation": "workspace:*",
+    "@pagopa/io-wallet-oauth2": "workspace:*",
+    "@pagopa/io-wallet-utils": "workspace:*",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "jose": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
   packages/oid-federation:
     dependencies:
       '@pagopa/io-wallet-utils':
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../utils
       buffer:
         specifier: 'catalog:'
@@ -146,13 +146,13 @@ importers:
         specifier: 'catalog:'
         version: 0.4.3
       '@pagopa/io-wallet-oauth2':
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../oauth2
       '@pagopa/io-wallet-oid-federation':
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../oid-federation
       '@pagopa/io-wallet-utils':
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../utils
       zod:
         specifier: 'catalog:'


### PR DESCRIPTION
## Problem

`packages/oid-federation/package.json` and `packages/oid4vp/package.json` used the bare `workspace:` specifier (without the `*` range selector) for their intra-monorepo dependencies.

During `pnpm publish`, pnpm replaces `workspace:*` with the concrete resolved version of the local package. The bare `workspace:` form (no range) is not replaced correctly and ends up as a literal `workspace:` string in the published `package.json`, making those dependencies unresolvable for consumers installing from npm.

## Fix

Replace every `workspace:` → `workspace:*` in:

- `packages/oid-federation/package.json` (`@pagopa/io-wallet-utils`)
- `packages/oid4vp/package.json` (`@pagopa/io-wallet-utils`, `@pagopa/io-wallet-oauth2`, `@pagopa/io-wallet-oid-federation`)

`pnpm-lock.yaml` updated accordingly.
