### PR TITLE
Generate DPoP-bound Refresh Token

### DIFF
--- a/.changeset/true-areas-design.md
+++ b/.changeset/true-areas-design.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oauth2": patch
+---
+
+Generate DPoP-bound Refresh Token

--- a/packages/oauth2/src/access-token/__tests__/create-token-response.test.ts
+++ b/packages/oauth2/src/access-token/__tests__/create-token-response.test.ts
@@ -38,17 +38,50 @@ const baseOptions: CreateAccessTokenResponseOptions = {
   tokenType: "Bearer",
 };
 
+const RT_JTI_BYTES = new Uint8Array([
+  0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+  0x0e, 0x0f, 0x10,
+]);
+
+// bytes[6] = 0x07 -> (0x07 & 0x0f) | 0x40 = 0x47 (version 4)
+// bytes[8] = 0x09 -> (0x09 & 0x3f) | 0x80 = 0x89 (variant 10)
+const RT_EXPECTED_JTI = "01020304-0506-4708-890a-0b0c0d0e0f10";
+
+interface SignJwtCallArgs {
+  header: { typ?: string };
+  payload: Record<string, unknown>;
+}
+
+function findSignJwtCallByTyp(typ: string): SignJwtCallArgs {
+  const call = mockCallbacks.signJwt.mock.calls.find(
+    (callArgs) => (callArgs[1] as SignJwtCallArgs).header.typ === typ,
+  );
+  if (!call) {
+    throw new Error(`No signJwt call found with header.typ = ${typ}`);
+  }
+  return call[1] as SignJwtCallArgs;
+}
+
+function setupMockCallbacks(): void {
+  vi.restoreAllMocks();
+  mockCallbacks.generateRandom.mockImplementation(async (byteLength: number) =>
+    byteLength === 16 ? RT_JTI_BYTES : new Uint8Array([1, 2, 3, 4]),
+  );
+  mockCallbacks.hash.mockResolvedValue(new Uint8Array([9, 10, 11, 12]));
+  mockCallbacks.signJwt.mockImplementation(
+    async (_signer: unknown, jwt: { header: { typ?: string } }) => ({
+      jwt:
+        jwt.header.typ === "rt+jwt"
+          ? "signed-refresh-token-jwt"
+          : "signed-access-token-jwt",
+      signerJwk: mockSigner.publicJwk,
+    }),
+  );
+}
+
 describe("createAccessTokenResponse", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-    mockCallbacks.generateRandom.mockResolvedValue(
-      new Uint8Array([1, 2, 3, 4]),
-    );
-    mockCallbacks.hash.mockResolvedValue(new Uint8Array([9, 10, 11, 12]));
-    mockCallbacks.signJwt.mockResolvedValue({
-      jwt: "signed-access-token-jwt",
-      signerJwk: mockSigner.publicJwk,
-    });
+    setupMockCallbacks();
   });
 
   it("creates a full DPoP-bound access token response", async () => {
@@ -66,7 +99,6 @@ describe("createAccessTokenResponse", () => {
         jwk: mockSigner.publicJwk,
       },
       nbf: 1704067200,
-      refreshToken: "refresh-token-value",
       tokenType: "DPoP",
     });
 
@@ -79,7 +111,6 @@ describe("createAccessTokenResponse", () => {
         },
       ],
       expires_in: 300,
-      refresh_token: "refresh-token-value",
       token_type: "DPoP",
     });
   });
@@ -192,6 +223,186 @@ describe("createAccessTokenResponse", () => {
       expect.objectContaining({
         custom_claim: "custom-value",
       }),
+    );
+  });
+
+  it("rejects the removed refreshToken option at compile time", () => {
+    const invalidOptions: CreateAccessTokenResponseOptions = {
+      ...baseOptions,
+      // @ts-expect-error refreshToken was removed in favor of refreshTokenExpiresInSeconds
+      refreshToken: "refresh-token-value",
+    };
+
+    expect(invalidOptions).toBeDefined();
+  });
+});
+
+describe("createAccessTokenResponse - Refresh Token issuance", () => {
+  const dpopOptions: CreateAccessTokenResponseOptions = {
+    ...baseOptions,
+    dpop: {
+      jwk: mockSigner.publicJwk,
+    },
+    refreshTokenExpiresInSeconds: 3600,
+    tokenType: "DPoP",
+  };
+
+  beforeEach(() => {
+    setupMockCallbacks();
+  });
+
+  it("issues a signed DPoP-bound Refresh Token JWT as refresh_token", async () => {
+    const result = await createAccessTokenResponse(dpopOptions);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        refresh_token: "signed-refresh-token-jwt",
+      }),
+    );
+  });
+
+  it("builds the Refresh Token header with typ=rt+jwt, alg, and kid", async () => {
+    await createAccessTokenResponse(dpopOptions);
+
+    expect(mockCallbacks.signJwt).toHaveBeenCalledWith(mockSigner, {
+      header: {
+        alg: "ES256",
+        kid: "test-kid",
+        typ: "rt+jwt",
+      },
+      payload: expect.any(Object),
+    });
+  });
+
+  it("resolves kid from signer.kid when present, overriding publicJwk.kid", async () => {
+    const signerWithKid = {
+      ...mockSigner,
+      kid: "signer-level-kid",
+    };
+
+    await createAccessTokenResponse({
+      ...dpopOptions,
+      signer: signerWithKid,
+    });
+
+    expect(mockCallbacks.signJwt).toHaveBeenCalledWith(
+      signerWithKid,
+      expect.objectContaining({
+        header: expect.objectContaining({ kid: "signer-level-kid" }),
+      }),
+    );
+  });
+
+  it("builds the Refresh Token payload with every mandatory claim", async () => {
+    await createAccessTokenResponse(dpopOptions);
+
+    expect(mockCallbacks.signJwt).toHaveBeenCalledWith(mockSigner, {
+      header: expect.any(Object),
+      payload: {
+        aud: "https://as.example.com",
+        client_id: "wallet-client-id",
+        cnf: { jkt: "CQoLDA" },
+        exp: 1704070800,
+        iat: 1704067200,
+        iss: "https://as.example.com",
+        jti: RT_EXPECTED_JTI,
+        nbf: 1704067500,
+        sub: "subject-id",
+      },
+    });
+  });
+
+  it("sets Refresh Token nbf equal to the Access Token exp", async () => {
+    await createAccessTokenResponse(dpopOptions);
+
+    const accessTokenCall = findSignJwtCallByTyp("at+jwt");
+    const refreshTokenCall = findSignJwtCallByTyp("rt+jwt");
+
+    expect(refreshTokenCall.payload.nbf).toBe(accessTokenCall.payload.exp);
+  });
+
+  it("binds both Access Token and Refresh Token to the same DPoP key via cnf.jkt", async () => {
+    await createAccessTokenResponse(dpopOptions);
+
+    const accessTokenCall = findSignJwtCallByTyp("at+jwt");
+    const refreshTokenCall = findSignJwtCallByTyp("rt+jwt");
+
+    expect((refreshTokenCall.payload.cnf as { jkt: string }).jkt).toBe(
+      (accessTokenCall.payload.cnf as { jkt: string }).jkt,
+    );
+  });
+
+  it("generates a canonical UUID v4 jti from 16 random bytes", async () => {
+    await createAccessTokenResponse(dpopOptions);
+
+    expect(mockCallbacks.generateRandom).toHaveBeenCalledWith(16);
+    expect(mockCallbacks.signJwt).toHaveBeenCalledWith(mockSigner, {
+      header: expect.any(Object),
+      payload: expect.objectContaining({ jti: RT_EXPECTED_JTI }),
+    });
+  });
+
+  it("omits refresh_token when refreshTokenExpiresInSeconds is not provided", async () => {
+    const result = await createAccessTokenResponse(baseOptions);
+
+    expect(result.refresh_token).toBeUndefined();
+    expect(mockCallbacks.signJwt).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when refreshTokenExpiresInSeconds does not extend beyond the Access Token lifetime", async () => {
+    await expect(
+      createAccessTokenResponse({
+        ...dpopOptions,
+        refreshTokenExpiresInSeconds: 300,
+      }),
+    ).rejects.toThrow(
+      "refreshTokenExpiresInSeconds (300) must be greater than expiresInSeconds (300)",
+    );
+  });
+
+  it("throws when refreshTokenExpiresInSeconds is zero or negative", async () => {
+    await expect(
+      createAccessTokenResponse({
+        ...dpopOptions,
+        refreshTokenExpiresInSeconds: 0,
+      }),
+    ).rejects.toThrow(
+      "refreshTokenExpiresInSeconds (0) must be greater than expiresInSeconds (300)",
+    );
+  });
+
+  it("throws when refreshTokenExpiresInSeconds is provided but tokenType is not DPoP", async () => {
+    await expect(
+      createAccessTokenResponse({
+        ...baseOptions,
+        refreshTokenExpiresInSeconds: 3600,
+        tokenType: "Bearer",
+      }),
+    ).rejects.toThrow(
+      "refreshTokenExpiresInSeconds was provided but Refresh Token issuance requires tokenType to be 'DPoP' with a dpop public key.",
+    );
+  });
+
+  it("throws when the signer has no resolvable kid for the Refresh Token", async () => {
+    const signerWithoutKid = {
+      alg: "ES256",
+      method: "jwk" as const,
+      publicJwk: {
+        crv: "P-256",
+        kty: "EC",
+        x: "test-x-value",
+        y: "test-y-value",
+      },
+    };
+
+    await expect(
+      createAccessTokenResponse({
+        ...dpopOptions,
+        dpop: { jwk: signerWithoutKid.publicJwk },
+        signer: signerWithoutKid,
+      }),
+    ).rejects.toThrow(
+      "Unable to resolve a kid for the Refresh Token JOSE header.",
     );
   });
 });

--- a/packages/oauth2/src/access-token/__tests__/create-token-response.test.ts
+++ b/packages/oauth2/src/access-token/__tests__/create-token-response.test.ts
@@ -130,7 +130,7 @@ describe("createAccessTokenResponse", () => {
         exp: 1704067500,
         iat: 1704067200,
         iss: "https://as.example.com",
-        jti: "AQIDBA",
+        jti: RT_EXPECTED_JTI,
         sub: "subject-id",
       }),
     });

--- a/packages/oauth2/src/access-token/create-token-response.ts
+++ b/packages/oauth2/src/access-token/create-token-response.ts
@@ -1,5 +1,6 @@
 import {
   CallbackContext,
+  GenerateRandomCallback,
   HashAlgorithm,
   JwtSigner,
   calculateJwkThumbprint,
@@ -7,7 +8,6 @@ import {
 import {
   addSecondsToDate,
   dateToSeconds,
-  encodeToBase64Url,
   parseWithErrorHandling,
 } from "@pagopa/io-wallet-utils";
 
@@ -18,10 +18,62 @@ import {
   AccessTokenProfileJwtHeader,
   AccessTokenProfileJwtPayload,
   AccessTokenResponse,
+  RefreshTokenProfileJwtHeader,
+  RefreshTokenProfileJwtPayload,
   zAccessTokenProfileJwtHeader,
   zAccessTokenProfileJwtPayload,
   zAccessTokenResponse,
+  zRefreshTokenProfileJwtHeader,
+  zRefreshTokenProfileJwtPayload,
 } from "./z-token";
+
+const UUID_BYTE_LENGTH = 16;
+
+/**
+ * Generates an RFC 4122 version 4 UUID using 16 random bytes obtained through
+ * the supplied `generateRandom` callback.
+ *
+ * @param generateRandom - Callback used to source cryptographically secure random bytes.
+ * @returns Canonical lowercase UUID v4 string.
+ */
+async function generateUuidV4(
+  generateRandom: GenerateRandomCallback,
+): Promise<string> {
+  const bytes = await generateRandom(UUID_BYTE_LENGTH);
+  // RFC 4122 requires setting the version (0100) and variant (10) bits directly.
+  // eslint-disable-next-line no-bitwise
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  // eslint-disable-next-line no-bitwise
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .match(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/);
+
+  if (!hex) {
+    throw new CreateTokenResponseError(
+      "Unable to generate a valid UUID v4 from the provided random bytes.",
+    );
+  }
+
+  return `${hex[1]}-${hex[2]}-${hex[3]}-${hex[4]}-${hex[5]}`;
+}
+
+/**
+ * Resolves the `kid` to include in the Refresh Token JOSE header.
+ *
+ * @param signer - Signer descriptor used to sign the Refresh Token.
+ * @returns The signer's key identifier, or `undefined` if none can be resolved.
+ */
+function resolveRefreshTokenKid(signer: JwtSigner): string | undefined {
+  if (signer.kid) {
+    return signer.kid;
+  }
+  if (signer.method === "jwk") {
+    return signer.publicJwk.kid;
+  }
+  return undefined;
+}
 
 export interface CreateAccessTokenResponseOptions {
   /**
@@ -74,9 +126,16 @@ export interface CreateAccessTokenResponseOptions {
   now?: Date;
 
   /**
-   * Optional refresh token included in the OAuth token response.
+   * Requests issuance of a DPoP-bound Refresh Token JWT by specifying its
+   * lifetime in seconds. The Refresh Token `exp` is set to `now +
+   * refreshTokenExpiresInSeconds` and must be later than the Access Token
+   * `exp` (`nbf` of the Refresh Token).
+   *
+   * Requires `tokenType` to be `DPoP` and `dpop` to be provided. Omit this
+   * option to keep the specification's optional Refresh Token behavior
+   * (e.g. Bearer-only PDND responses).
    */
-  refreshToken?: string;
+  refreshTokenExpiresInSeconds?: number;
 
   /**
    * Optional scope string included in both the access token JWT payload and token
@@ -109,9 +168,15 @@ export interface CreateAccessTokenResponseOptions {
  * `exp`, and a random `jti`. When `dpop` is provided, `cnf.jkt` is added using
  * the SHA-256 JWK thumbprint.
  *
+ * When `refreshTokenExpiresInSeconds` is provided, a DPoP-bound Refresh Token
+ * JWT (`typ=rt+jwt`) is generated, signed, and returned as `refresh_token`.
+ * Refresh Token issuance requires `tokenType` to be `DPoP` with a `dpop`
+ * public key, and results in `nbf` equal to the Access Token `exp` and `exp`
+ * later than that.
+ *
  * @param options - Access token response creation options.
- * @returns OAuth token response with a signed access token JWT.
- * @throws {CreateTokenResponseError} If DPoP binding is required but missing, or if response creation fails, including validation failures from the generated JWT header or payload.
+ * @returns OAuth token response with a signed access token JWT, and a signed Refresh Token JWT when requested.
+ * @throws {CreateTokenResponseError} If DPoP binding is required but missing, if Refresh Token issuance is requested without a valid DPoP configuration or lifetime, if the signer has no resolvable `kid` for the Refresh Token, or if response creation otherwise fails, including validation failures from the generated JWT headers or payloads.
  * @throws {ValidationError} If the generated JWT header or payload fails validation.
  */
 export async function createAccessTokenResponse(
@@ -126,6 +191,37 @@ export async function createAccessTokenResponse(
       );
     }
 
+    if (
+      options.refreshTokenExpiresInSeconds !== undefined &&
+      (options.tokenType !== "DPoP" || !options.dpop)
+    ) {
+      throw new CreateTokenResponseError(
+        "refreshTokenExpiresInSeconds was provided but Refresh Token issuance requires tokenType to be 'DPoP' with a dpop public key.",
+      );
+    }
+
+    if (
+      options.refreshTokenExpiresInSeconds !== undefined &&
+      options.refreshTokenExpiresInSeconds <= options.expiresInSeconds
+    ) {
+      throw new CreateTokenResponseError(
+        `refreshTokenExpiresInSeconds (${options.refreshTokenExpiresInSeconds}) must be greater than expiresInSeconds (${options.expiresInSeconds}) so the Refresh Token remains usable after the Access Token expires.`,
+      );
+    }
+
+    const dpopJkt = options.dpop
+      ? await calculateJwkThumbprint({
+          hashAlgorithm: HashAlgorithm.Sha256,
+          hashCallback: options.callbacks.hash,
+          jwk: options.dpop.jwk,
+        })
+      : undefined;
+
+    const accessTokenExpiresAt = addSecondsToDate(
+      now,
+      options.expiresInSeconds,
+    );
+
     const header = parseWithErrorHandling(zAccessTokenProfileJwtHeader, {
       ...jwtHeaderFromJwtSigner(options.signer),
       typ: "at+jwt",
@@ -135,19 +231,11 @@ export async function createAccessTokenResponse(
       ...options.additionalPayload,
       aud: options.audience,
       client_id: options.clientId,
-      cnf: options.dpop
-        ? {
-            jkt: await calculateJwkThumbprint({
-              hashAlgorithm: HashAlgorithm.Sha256,
-              hashCallback: options.callbacks.hash,
-              jwk: options.dpop.jwk,
-            }),
-          }
-        : undefined,
-      exp: dateToSeconds(addSecondsToDate(now, options.expiresInSeconds)),
+      cnf: dpopJkt ? { jkt: dpopJkt } : undefined,
+      exp: dateToSeconds(accessTokenExpiresAt),
       iat: dateToSeconds(now),
       iss: options.authorizationServer,
-      jti: encodeToBase64Url(await options.callbacks.generateRandom(32)),
+      jti: await generateUuidV4(options.callbacks.generateRandom),
       nbf: options.nbf,
       scope: options.scope,
       sub: options.subject,
@@ -158,11 +246,58 @@ export async function createAccessTokenResponse(
       payload,
     });
 
+    let refreshToken: string | undefined;
+
+    if (options.refreshTokenExpiresInSeconds !== undefined && dpopJkt) {
+      const kid = resolveRefreshTokenKid(options.signer);
+      if (!kid) {
+        throw new CreateTokenResponseError(
+          "Unable to resolve a kid for the Refresh Token JOSE header. Provide signer.kid or a publicJwk.kid.",
+        );
+      }
+
+      const refreshTokenHeader = parseWithErrorHandling(
+        zRefreshTokenProfileJwtHeader,
+        {
+          alg: options.signer.alg,
+          kid,
+          typ: "rt+jwt",
+        } satisfies RefreshTokenProfileJwtHeader,
+      );
+
+      const refreshTokenPayload = parseWithErrorHandling(
+        zRefreshTokenProfileJwtPayload,
+        {
+          aud: options.authorizationServer,
+          client_id: options.clientId,
+          cnf: { jkt: dpopJkt },
+          exp: dateToSeconds(
+            addSecondsToDate(now, options.refreshTokenExpiresInSeconds),
+          ),
+          iat: dateToSeconds(now),
+          iss: options.authorizationServer,
+          jti: await generateUuidV4(options.callbacks.generateRandom),
+          nbf: dateToSeconds(accessTokenExpiresAt),
+          sub: options.subject,
+        } satisfies RefreshTokenProfileJwtPayload,
+      );
+
+      const refreshTokenSignResult = await options.callbacks.signJwt(
+        options.signer,
+        {
+          header: refreshTokenHeader,
+          payload: refreshTokenPayload,
+        },
+      );
+
+      refreshToken = refreshTokenSignResult.jwt;
+    }
+
     const accessTokenResponse = parseWithErrorHandling(zAccessTokenResponse, {
       ...options.additionalPayload,
       access_token: jwt,
       expires_in: options.expiresInSeconds,
-      refresh_token: options.refreshToken,
+      refresh_token: refreshToken,
       token_type: options.tokenType,
     } satisfies AccessTokenResponse);
 

--- a/packages/oauth2/src/access-token/create-token-response.ts
+++ b/packages/oauth2/src/access-token/create-token-response.ts
@@ -69,6 +69,9 @@ function resolveRefreshTokenKid(signer: JwtSigner): string | undefined {
   if (signer.kid) {
     return signer.kid;
   }
+  if (signer.method === "did") {
+    return signer.didUrl;
+  }
   if (signer.method === "jwk") {
     return signer.publicJwk.kid;
   }

--- a/packages/oauth2/src/access-token/create-token-response.ts
+++ b/packages/oauth2/src/access-token/create-token-response.ts
@@ -1,6 +1,6 @@
 import {
   CallbackContext,
-  GenerateRandomCallback,
+  type GenerateRandomCallback,
   HashAlgorithm,
   JwtSigner,
   calculateJwkThumbprint,

--- a/packages/oauth2/src/access-token/z-token.ts
+++ b/packages/oauth2/src/access-token/z-token.ts
@@ -76,3 +76,32 @@ export const zAccessTokenProfileJwtPayload = z.looseObject({
 export type AccessTokenProfileJwtPayload = z.infer<
   typeof zAccessTokenProfileJwtPayload
 >;
+
+export const zRefreshTokenProfileJwtHeader = z.looseObject({
+  ...zJwtHeader.shape,
+  kid: z.string(),
+  typ: z.literal("rt+jwt"),
+});
+
+export type RefreshTokenProfileJwtHeader = z.infer<
+  typeof zRefreshTokenProfileJwtHeader
+>;
+
+export const zRefreshTokenProfileJwtPayload = z.looseObject({
+  ...zJwtPayload.shape,
+  aud: z.string(),
+  client_id: z.string(),
+  cnf: z.object({
+    jkt: z.string(),
+  }),
+  exp: z.number().int(),
+  iat: z.number().int(),
+  iss: z.string(),
+  jti: z.uuidv4(),
+  nbf: z.number().int(),
+  sub: z.string(),
+});
+
+export type RefreshTokenProfileJwtPayload = z.infer<
+  typeof zRefreshTokenProfileJwtPayload
+>;

--- a/packages/oauth2/src/access-token/z-token.ts
+++ b/packages/oauth2/src/access-token/z-token.ts
@@ -97,7 +97,7 @@ export const zRefreshTokenProfileJwtPayload = z.looseObject({
   exp: z.number().int(),
   iat: z.number().int(),
   iss: z.string(),
-  jti: z.uuidv4(),
+  jti: z.string().max(MAX_JTI_LENGTH),
   nbf: z.number().int(),
   sub: z.string(),
 });


### PR DESCRIPTION
#### List of Changes
- Introduced functionality to generate a DPoP-bound refresh token.
- Added new JWT header and payload structures for the refresh token.
- Updated tests to validate the issuance and properties of the refresh token.

#### Motivation and Context
This change is required to enhance the OAuth2 implementation by allowing the issuance of refresh tokens that are bound to DPoP (Demonstration of Proof-of-Possession) keys. This improves security by ensuring that refresh tokens can only be used by the client that originally requested them.

#### How Has This Been Tested?
The changes have been tested through unit tests that cover the generation of refresh tokens, ensuring that they meet the required specifications and that the correct errors are thrown for invalid configurations. Tests were run in a controlled environment to validate the functionality and integration with existing access token generation logic.

