### PR TITLE
chore: [SIW-4687] Add Wallet Solution metadata schema for v1.4

### DIFF
--- a/.changeset/old-deserts-crash.md
+++ b/.changeset/old-deserts-crash.md
@@ -1,0 +1,6 @@
+---
+"@pagopa/io-wallet-oid-federation": patch
+"@pagopa/io-wallet-oid4vci": patch
+---
+
+Support Wallet Solution metadata conforming to v1.4

--- a/packages/oid-federation/src/index.ts
+++ b/packages/oid-federation/src/index.ts
@@ -66,6 +66,11 @@ export {
   itWalletSolutionEntityMetadata as itWalletSolutionEntityMetadataV1_3,
 } from "./metadata/entity/v1.3/itWalletSolution";
 export type { ItWalletSolutionEntityMetadata as ItWalletSolutionEntityMetadataV1_3 } from "./metadata/entity/v1.3/itWalletSolution";
+export {
+  itWalletSolutionEntityIdentifier as itWalletSolutionEntityIdentifierV1_4,
+  itWalletSolutionEntityMetadata as itWalletSolutionEntityMetadataV1_4,
+} from "./metadata/entity/v1.4/itWalletSolution";
+export type { ItWalletSolutionEntityMetadata as ItWalletSolutionEntityMetadataV1_4 } from "./metadata/entity/v1.4/itWalletSolution";
 export * from "./metadata/itWalletMetadata";
 export * from "./metadata/operator/metadata-merge-strategy";
 export type * from "./metadata/operator/metadata-operator";

--- a/packages/oid-federation/src/metadata/__tests__/itWalletMetadata.test.ts
+++ b/packages/oid-federation/src/metadata/__tests__/itWalletMetadata.test.ts
@@ -32,6 +32,23 @@ const validV1_3Metadata = {
   },
 };
 
+const validV1_4Metadata = {
+  wallet_solution: {
+    logo_uri: "https://wallet-solution.example.com/logo.svg",
+    wallet_metadata: {
+      authorization_endpoint: "https://wallet-solution.example.com/authorize",
+      client_id_prefixes_supported: ["openid_federation"],
+      credential_offer_endpoint:
+        "https://wallet-solution.example.com/credential-offer",
+      request_object_signing_alg_values_supported: ["ES256"],
+      vp_formats_supported: {
+        "dc+sd-jwt": {},
+      },
+      wallet_name: "Example Wallet",
+    },
+  },
+};
+
 describe("isItWalletMetadataVersion", () => {
   it("should identify valid v1.0 metadata", () => {
     expect(
@@ -45,12 +62,24 @@ describe("isItWalletMetadataVersion", () => {
     ).toBe(true);
   });
 
+  it("should identify valid v1.4 metadata", () => {
+    expect(
+      isItWalletMetadataVersion(validV1_4Metadata, ItWalletSpecsVersion.V1_4),
+    ).toBe(true);
+  });
+
   it("should reject metadata for a different supported version", () => {
     expect(
       isItWalletMetadataVersion(validV1_0Metadata, ItWalletSpecsVersion.V1_3),
     ).toBe(false);
     expect(
       isItWalletMetadataVersion(validV1_3Metadata, ItWalletSpecsVersion.V1_0),
+    ).toBe(false);
+    expect(
+      isItWalletMetadataVersion(validV1_0Metadata, ItWalletSpecsVersion.V1_4),
+    ).toBe(false);
+    expect(
+      isItWalletMetadataVersion(validV1_4Metadata, ItWalletSpecsVersion.V1_3),
     ).toBe(false);
   });
 });
@@ -74,6 +103,15 @@ describe("parseItWalletMetadataForVersion", () => {
     ).toEqual(validV1_3Metadata);
   });
 
+  it("should parse valid v1.4 metadata", () => {
+    expect(
+      parseItWalletMetadataForVersion(
+        validV1_4Metadata,
+        ItWalletSpecsVersion.V1_4,
+      ),
+    ).toEqual(validV1_4Metadata);
+  });
+
   it("should reject metadata for a different supported version", () => {
     expect(() =>
       parseItWalletMetadataForVersion(
@@ -84,9 +122,23 @@ describe("parseItWalletMetadataForVersion", () => {
 
     expect(() =>
       parseItWalletMetadataForVersion(
+        validV1_0Metadata,
+        ItWalletSpecsVersion.V1_4,
+      ),
+    ).toThrow(/invalid v1\.4 metadata provided/);
+
+    expect(() =>
+      parseItWalletMetadataForVersion(
         validV1_3Metadata,
         ItWalletSpecsVersion.V1_0,
       ),
     ).toThrow(/invalid v1\.0 metadata provided/);
+
+    expect(() =>
+      parseItWalletMetadataForVersion(
+        validV1_4Metadata,
+        ItWalletSpecsVersion.V1_3,
+      ),
+    ).toThrow(/invalid v1\.3 metadata provided/);
   });
 });

--- a/packages/oid-federation/src/metadata/entity/v1.4/itWalletSolution.ts
+++ b/packages/oid-federation/src/metadata/entity/v1.4/itWalletSolution.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { jsonWebKeySetSchema } from "../../../jwk/jwk";
+
+const walletMetadataSchema = z.looseObject({
+  authorization_endpoint: z.url(),
+  client_id_prefixes_supported: z.array(
+    z.enum(["openid_federation", "x509_hash"]),
+  ),
+  credential_offer_endpoint: z.url(),
+  request_object_signing_alg_values_supported: z.array(z.string()),
+  response_types_supported: z.array(z.string()).optional(),
+  vp_formats_supported: z.record(z.string(), z.looseObject({})),
+  wallet_name: z.string(),
+});
+
+export const itWalletSolutionEntityMetadata = z.looseObject({
+  jwks: jsonWebKeySetSchema.optional(),
+  jwks_uri: z.url().optional(),
+  // logo_uri MIME type MUST be application/svg per spec; validated at fetch-time
+  logo_uri: z.url(),
+  signed_jwks_uri: z.url().optional(),
+  wallet_metadata: walletMetadataSchema,
+});
+
+export type ItWalletSolutionEntityMetadata = z.input<
+  typeof itWalletSolutionEntityMetadata
+>;
+
+export const itWalletSolutionEntityIdentifier = "wallet_solution";

--- a/packages/oid-federation/src/metadata/itWalletMetadata.ts
+++ b/packages/oid-federation/src/metadata/itWalletMetadata.ts
@@ -41,6 +41,10 @@ import {
   itWalletSolutionEntityIdentifier as itWalletSolutionEntityIdentifierV1_3,
   itWalletSolutionEntityMetadata as itWalletSolutionEntityMetadataV1_3,
 } from "./entity/v1.3/itWalletSolution";
+import {
+  itWalletSolutionEntityIdentifier as itWalletSolutionEntityIdentifierV1_4,
+  itWalletSolutionEntityMetadata as itWalletSolutionEntityMetadataV1_4,
+} from "./entity/v1.4/itWalletSolution";
 
 // v1.0 combined metadata
 export const itWalletMetadataV1_0 = z.strictObject({
@@ -69,21 +73,41 @@ export const itWalletMetadataV1_3 = z.strictObject({
     itWalletSolutionEntityMetadataV1_3.optional(),
 });
 
-// Union — used by entity statement / entity configuration claims
-// v1.3 is tried first so that v1.3-specific fields are preserved during parsing
-export const itWalletMetadataSchema =
-  itWalletMetadataV1_3.or(itWalletMetadataV1_0);
+// v1.4 combined metadata (only wallet_solution diverges from v1.3)
+export const itWalletMetadataV1_4 = itWalletMetadataV1_3.extend({
+  [itWalletSolutionEntityIdentifierV1_4]:
+    itWalletSolutionEntityMetadataV1_4.optional(),
+});
 
-export type ItWalletMetadataV1_0 = z.output<typeof itWalletMetadataV1_0>;
-export type ItWalletMetadataV1_3 = z.output<typeof itWalletMetadataV1_3>;
-export type ItWalletMetadata = ItWalletMetadataV1_0 | ItWalletMetadataV1_3;
+// Union — used by entity statement / entity configuration claims.
+// Order matters: v1.4 only relaxes v1.3 wallet_solution constraints, so every v1.3
+// document also satisfies v1.4. The narrower schema must stay first, otherwise v1.3
+// documents would match the v1.4 branch. New versions go after the ones they relax.
+export const itWalletMetadataSchema = itWalletMetadataV1_3
+  .or(itWalletMetadataV1_4)
+  .or(itWalletMetadataV1_0);
+
+// Type-level registry of version -> schema. The generic constraint acts as a
+// `satisfies` for types: omitting a version is a compile error here, and every
+// version-specific metadata type derives from this single mapping.
+type SchemaByVersion<T extends Record<ItWalletSpecsVersion, z.ZodType>> = T;
+
+type ItWalletMetadataSchemaByVersion = SchemaByVersion<{
+  [ItWalletSpecsVersion.V1_0]: typeof itWalletMetadataV1_0;
+  [ItWalletSpecsVersion.V1_3]: typeof itWalletMetadataV1_3;
+  [ItWalletSpecsVersion.V1_4]: typeof itWalletMetadataV1_4;
+}>;
 
 export type ItWalletMetadataByVersion<V extends ItWalletSpecsVersion> =
-  V extends ItWalletSpecsVersion.V1_0
-    ? ItWalletMetadataV1_0
-    : V extends ItWalletSpecsVersion.V1_3 | ItWalletSpecsVersion.V1_4
-      ? ItWalletMetadataV1_3
-      : never;
+  z.output<ItWalletMetadataSchemaByVersion[V]>;
+
+export type ItWalletMetadataV1_0 =
+  ItWalletMetadataByVersion<ItWalletSpecsVersion.V1_0>;
+export type ItWalletMetadataV1_3 =
+  ItWalletMetadataByVersion<ItWalletSpecsVersion.V1_3>;
+export type ItWalletMetadataV1_4 =
+  ItWalletMetadataByVersion<ItWalletSpecsVersion.V1_4>;
+export type ItWalletMetadata = ItWalletMetadataByVersion<ItWalletSpecsVersion>;
 
 /**
  * Checks whether a metadata object matches the schema for a specific IT-Wallet version.
@@ -103,7 +127,7 @@ export function isItWalletMetadataVersion<V extends ItWalletSpecsVersion>(
     [ItWalletSpecsVersion.V1_3]: () =>
       itWalletMetadataV1_3.safeParse(metadata).success,
     [ItWalletSpecsVersion.V1_4]: () =>
-      itWalletMetadataV1_3.safeParse(metadata).success,
+      itWalletMetadataV1_4.safeParse(metadata).success,
   });
 }
 
@@ -135,7 +159,7 @@ export function parseItWalletMetadataForVersion<V extends ItWalletSpecsVersion>(
       ),
     [ItWalletSpecsVersion.V1_4]: () =>
       parseWithErrorHandling(
-        itWalletMetadataV1_3,
+        itWalletMetadataV1_4,
         metadata,
         "invalid v1.4 metadata provided",
       ),

--- a/packages/oid4vci/src/index.ts
+++ b/packages/oid4vci/src/index.ts
@@ -62,9 +62,11 @@ export {
   type MetadataResponse,
   type MetadataResponseV1_0,
   type MetadataResponseV1_3,
+  type MetadataResponseV1_4,
   zMetadataResponse,
   zMetadataResponseV1_0,
   zMetadataResponseV1_3,
+  zMetadataResponseV1_4,
 } from "./metadata/z-metadata-response";
 export * from "./wallet-provider/WalletProvider";
 export type * from "./wallet-provider/types";

--- a/packages/oid4vci/src/metadata/fetch-metadata.ts
+++ b/packages/oid4vci/src/metadata/fetch-metadata.ts
@@ -20,6 +20,7 @@ import {
   MetadataResponse,
   zMetadataResponseV1_0,
   zMetadataResponseV1_3,
+  zMetadataResponseV1_4,
   zPartialIssuerMetadata,
 } from "./z-metadata-response";
 
@@ -313,6 +314,34 @@ async function fallbackDiscovery(
   };
 }
 
+/**
+ * Fetch raw metadata with federation discovery or the available fallback mechanisms.
+ * Metadata are returned raw without any version specific validation, that must be performed separately.
+ */
+const fetchMetadataWithFallbackDiscovery = async (
+  options: FetchMetadataOptions,
+): Promise<RawFederationResult | RawOid4vciResult> => {
+  const fetch = createFetcher(options.callbacks.fetch);
+  const federationResult = await tryFederationDiscovery(
+    fetch,
+    options.credentialIssuerUrl,
+    options.callbacks.verifyJwt,
+  );
+  const raw = federationResult
+    ? await applyFederationAuthorizationServerSelection(
+        fetch,
+        federationResult,
+        options.authorizationServer,
+        options.callbacks.verifyJwt,
+      )
+    : await fallbackDiscovery(
+        fetch,
+        options.credentialIssuerUrl,
+        options.authorizationServer,
+      );
+  return raw;
+};
+
 async function fetchMetadataV1_0(
   options: FetchMetadataOptions,
 ): Promise<MetadataResponse> {
@@ -337,28 +366,22 @@ async function fetchMetadataV1_0(
 async function fetchMetadataV1_3(
   options: FetchMetadataOptions,
 ): Promise<MetadataResponse> {
-  const fetch = createFetcher(options.callbacks.fetch);
-  const federationResult = await tryFederationDiscovery(
-    fetch,
-    options.credentialIssuerUrl,
-    options.callbacks.verifyJwt,
-  );
-  const raw = federationResult
-    ? await applyFederationAuthorizationServerSelection(
-        fetch,
-        federationResult,
-        options.authorizationServer,
-        options.callbacks.verifyJwt,
-      )
-    : await fallbackDiscovery(
-        fetch,
-        options.credentialIssuerUrl,
-        options.authorizationServer,
-      );
+  const raw = await fetchMetadataWithFallbackDiscovery(options);
   return parseWithErrorHandling(
     zMetadataResponseV1_3,
     raw,
     "Failed to parse v1.3 metadata response",
+  );
+}
+
+async function fetchMetadataV1_4(
+  options: FetchMetadataOptions,
+): Promise<MetadataResponse> {
+  const raw = await fetchMetadataWithFallbackDiscovery(options);
+  return parseWithErrorHandling(
+    zMetadataResponseV1_4,
+    raw,
+    "Failed to parse v1.4 metadata response",
   );
 }
 
@@ -368,8 +391,7 @@ const dispatchFetchMetadata = createVersionDispatcher<
 >({
   [ItWalletSpecsVersion.V1_0]: (o) => fetchMetadataV1_0(o),
   [ItWalletSpecsVersion.V1_3]: (o) => fetchMetadataV1_3(o),
-  // V1_4 reuses V1_3 metadata schema — no breaking changes between versions.
-  [ItWalletSpecsVersion.V1_4]: (o) => fetchMetadataV1_3(o),
+  [ItWalletSpecsVersion.V1_4]: (o) => fetchMetadataV1_4(o),
 });
 
 /**
@@ -385,7 +407,8 @@ const dispatchFetchMetadata = createVersionDispatcher<
  * On failure, falls back to `.well-known/openid-credential-issuer` + optional
  * `.well-known/oauth-authorization-server`. Returns `MetadataResponseV1_3`.
  *
- * **v1.4**: Identical behaviour to v1.3 — metadata schema is unchanged between versions.
+ * **v1.4**: Same discovery strategy as v1.3, validated against the v1.4 metadata schema.
+ * Returns `MetadataResponseV1_4`.
  *
  * Well-known paths are appended relative to the full `credentialIssuerUrl`, preserving
  * any path segment (e.g. `"https://issuer.example.it/v1"` →

--- a/packages/oid4vci/src/metadata/z-metadata-response.ts
+++ b/packages/oid4vci/src/metadata/z-metadata-response.ts
@@ -2,6 +2,7 @@ import {
   itWalletEntityStatementClaimsSchema,
   itWalletMetadataV1_0,
   itWalletMetadataV1_3,
+  itWalletMetadataV1_4,
 } from "@pagopa/io-wallet-oid-federation";
 import { z } from "zod";
 
@@ -24,14 +25,23 @@ export const zMetadataResponseV1_3 = z.object({
   openid_federation_claims: itWalletEntityStatementClaimsSchema.optional(),
 });
 
+export const zMetadataResponseV1_4 = zMetadataResponseV1_3.extend({
+  metadata: itWalletMetadataV1_4,
+});
+
 export const zMetadataResponse = z.union([
   zMetadataResponseV1_0,
   zMetadataResponseV1_3,
+  zMetadataResponseV1_4,
 ]);
 
 export type MetadataResponseV1_0 = z.infer<typeof zMetadataResponseV1_0>;
 export type MetadataResponseV1_3 = z.infer<typeof zMetadataResponseV1_3>;
-export type MetadataResponse = MetadataResponseV1_0 | MetadataResponseV1_3;
+export type MetadataResponseV1_4 = z.infer<typeof zMetadataResponseV1_4>;
+export type MetadataResponse =
+  | MetadataResponseV1_0
+  | MetadataResponseV1_3
+  | MetadataResponseV1_4;
 
 // For intermediate parsing in fallbackDiscovery:
 export const zPartialIssuerMetadata = z.looseObject({


### PR DESCRIPTION
#### List of Changes

**`oid-federation`**
- Add v1.4 `wallet_solution` metadata (`metadata/entity/v1.4/itWalletSolution.ts`): `response_modes_supported` removed, `response_types_supported` now optional.
- Add `itWalletMetadataV1_4` (extends v1.3, overrides `wallet_solution`) and route `V1_4` to it in `isItWalletMetadataVersion` / `parseItWalletMetadataForVersion`.
- Add it to `itWalletMetadataSchema` after v1.3 — v1.4 only relaxes constraints, so the narrower schema must be tried first.
- Derive `ItWalletMetadataByVersion` from a type-level version→schema registry, making a missing version a compile error.

**`oid4vci`**
- Add `zMetadataResponseV1_4` / `MetadataResponseV1_4` and point the `V1_4` branch of `fetchMetadata` at it.

#### Motivation and Context

IT-Wallet v1.4 drops `response_modes_supported` from `wallet_solution.wallet_metadata` and makes `response_types_supported` optional. `V1_4` previously reused the v1.3 schema, which *requires* `response_modes_supported` — so any compliant v1.4 document was rejected, both by `parseItWalletMetadataForVersion(..., V1_4)` and by `fetchMetadata`.

#### How Has This Been Tested?

- New unit tests for v1.4 parsing/type-guarding and cross-version rejection.