### PR TITLE
fix(oid4vp): conditional x5c authorization request header

### DIFF
--- a/.changeset/fuzzy-pens-flow.md
+++ b/.changeset/fuzzy-pens-flow.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid4vp": patch
+---
+
+Backport the IT-Wallet 1.4.4 LTS conditional `x5c` Request Object rule to OID4VP SDK profiles V1_3 and V1_4, allowing federation signers when `client_id` uses `openid_federation` while preserving x5c requirements for `x509_hash`.

--- a/packages/oid4vp/src/authorization-request/__tests__/create-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/create-authorization-request.test.ts
@@ -10,6 +10,7 @@ import { Oid4vpError } from "../../errors";
 import {
   type CreateAuthorizationRequestOptionsV1_0,
   type CreateAuthorizationRequestOptionsV1_3,
+  type CreateAuthorizationRequestOptionsV1_4,
   createAuthorizationRequest,
 } from "../create-authorization-request";
 import { Openid4vpAuthorizationRequestPayload } from "../z-authorization-request";
@@ -31,6 +32,10 @@ const configV1_3 = new IoWalletSdkConfig({
   itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
 });
 
+const configV1_4 = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_4,
+});
+
 const authorizationRequestPayload: Openid4vpAuthorizationRequestPayload = {
   client_id: "client-123",
   dcql_query: {},
@@ -40,6 +45,18 @@ const authorizationRequestPayload: Openid4vpAuthorizationRequestPayload = {
   response_type: "vp_token",
   response_uri: "https://wallet.example.org/response",
   state: "state-123",
+};
+
+const openidFederationAuthorizationRequestPayload = {
+  ...authorizationRequestPayload,
+  client_id: "openid_federation:https://rp.example.org",
+  iss: "openid_federation:https://rp.example.org",
+};
+
+const x509HashAuthorizationRequestPayload = {
+  ...authorizationRequestPayload,
+  client_id: "x509_hash:certificate-hash",
+  iss: "x509_hash:certificate-hash",
 };
 
 const jar = {
@@ -121,7 +138,7 @@ describe("createAuthorizationRequest", () => {
     });
   });
 
-  it("narrows signer requirements by config version at compile time", () => {
+  it("narrows V1_0 signer requirements by config version at compile time", () => {
     const optionsV1_0: CreateAuthorizationRequestOptionsV1_0 = {
       authorizationRequestPayload,
       callbacks,
@@ -136,8 +153,16 @@ describe("createAuthorizationRequest", () => {
       jar: jarV1_3,
     };
 
+    const optionsV1_4: CreateAuthorizationRequestOptionsV1_4 = {
+      authorizationRequestPayload,
+      callbacks,
+      config: configV1_4,
+      jar,
+    };
+
     expect(optionsV1_0.jar.jwtSigner.method).toBe("federation");
     expect(optionsV1_3.jar.jwtSigner.method).toBe("x5c");
+    expect(optionsV1_4.jar.jwtSigner.method).toBe("federation");
 
     const invalidV1_0 = {
       authorizationRequestPayload,
@@ -147,16 +172,7 @@ describe("createAuthorizationRequest", () => {
       jar: jarV1_3,
     } satisfies CreateAuthorizationRequestOptionsV1_0;
 
-    const invalidV1_3 = {
-      authorizationRequestPayload,
-      callbacks,
-      config: configV1_3,
-      // @ts-expect-error v1.3 only accepts x5c signers
-      jar,
-    } satisfies CreateAuthorizationRequestOptionsV1_3;
-
     expect(invalidV1_0).toBeDefined();
-    expect(invalidV1_3).toBeDefined();
   });
 
   it("does not overwrite additionalJwtPayload.aud when already provided", async () => {
@@ -233,6 +249,121 @@ describe("createAuthorizationRequest", () => {
     expect(result.authorizationRequest).toBe(
       "https://wallet.example.org/authorize?existing=1&client_id=client-123&request_uri=https%3A%2F%2Frp.example.org%2Frequest.jwt",
     );
+  });
+
+  it("creates a v1.3 openid_federation authorization request with a federation signer", async () => {
+    vi.mocked(createJarRequest).mockResolvedValue({
+      authorizationRequestJwt: "signed.jwt.value",
+      jarAuthorizationRequest: {
+        client_id: "openid_federation:https://rp.example.org",
+        request_uri: "https://rp.example.org/request.jwt",
+      },
+      signerJwk: {
+        crv: "P-256",
+        kty: "EC",
+        x: "x-value",
+        y: "y-value",
+      },
+    });
+
+    await createAuthorizationRequest({
+      authorizationRequestPayload: openidFederationAuthorizationRequestPayload,
+      callbacks,
+      config: configV1_3,
+      jar,
+    });
+
+    expect(createJarRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizationRequestHeader: {
+          alg: "ES256",
+          kid: "kid-123",
+          trust_chain: ["entity-statement-jwt"],
+          typ: "oauth-authz-req+jwt",
+        },
+      }),
+    );
+  });
+
+  it("creates a v1.4 openid_federation authorization request with a federation signer", async () => {
+    vi.mocked(createJarRequest).mockResolvedValue({
+      authorizationRequestJwt: "signed.jwt.value",
+      jarAuthorizationRequest: {
+        client_id: "openid_federation:https://rp.example.org",
+        request_uri: "https://rp.example.org/request.jwt",
+      },
+      signerJwk: {
+        crv: "P-256",
+        kty: "EC",
+        x: "x-value",
+        y: "y-value",
+      },
+    });
+
+    await createAuthorizationRequest({
+      authorizationRequestPayload: openidFederationAuthorizationRequestPayload,
+      callbacks,
+      config: configV1_4,
+      jar,
+    });
+
+    expect(createJarRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizationRequestHeader: {
+          alg: "ES256",
+          kid: "kid-123",
+          trust_chain: ["entity-statement-jwt"],
+          typ: "oauth-authz-req+jwt",
+        },
+      }),
+    );
+  });
+
+  it("creates an openid_federation authorization request with an x5c signer", async () => {
+    vi.mocked(createJarRequest).mockResolvedValue({
+      authorizationRequestJwt: "signed.jwt.value",
+      jarAuthorizationRequest: {
+        client_id: "openid_federation:https://rp.example.org",
+        request_uri: "https://rp.example.org/request.jwt",
+      },
+      signerJwk: {
+        crv: "P-256",
+        kty: "EC",
+        x: "x-value",
+        y: "y-value",
+      },
+    });
+
+    await createAuthorizationRequest({
+      authorizationRequestPayload: openidFederationAuthorizationRequestPayload,
+      callbacks,
+      config: configV1_3,
+      jar: jarV1_3,
+    });
+
+    expect(createJarRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorizationRequestHeader: {
+          alg: "ES256",
+          kid: "kid-123",
+          typ: "oauth-authz-req+jwt",
+          x5c: ["leaf-certificate"],
+        },
+      }),
+    );
+  });
+
+  it("rejects x509_hash authorization requests with a federation signer before JAR creation", async () => {
+    await expect(
+      createAuthorizationRequest({
+        authorizationRequestPayload: x509HashAuthorizationRequestPayload,
+        callbacks,
+        config: configV1_3,
+        jar,
+      }),
+    ).rejects.toThrow(Oid4vpError);
+
+    expect(createJarRequest).not.toHaveBeenCalled();
   });
 
   it("throws Oid4vpError when authorization payload is invalid", async () => {

--- a/packages/oid4vp/src/authorization-request/__tests__/create-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/create-authorization-request.test.ts
@@ -53,6 +53,12 @@ const openidFederationAuthorizationRequestPayload = {
   iss: "openid_federation:https://rp.example.org",
 };
 
+const legacyHttpsAuthorizationRequestPayload = {
+  ...authorizationRequestPayload,
+  client_id: "https://rp.example.org",
+  iss: "https://rp.example.org",
+};
+
 const x509HashAuthorizationRequestPayload = {
   ...authorizationRequestPayload,
   client_id: "x509_hash:certificate-hash",
@@ -217,7 +223,7 @@ describe("createAuthorizationRequest", () => {
     vi.mocked(createJarRequest).mockResolvedValue({
       authorizationRequestJwt: "signed.jwt.value",
       jarAuthorizationRequest: {
-        client_id: "client-123",
+        client_id: "x509_hash:certificate-hash",
         request_uri: "https://rp.example.org/request.jwt",
       },
       signerJwk: {
@@ -229,7 +235,7 @@ describe("createAuthorizationRequest", () => {
     });
 
     const result = await createAuthorizationRequest({
-      authorizationRequestPayload,
+      authorizationRequestPayload: x509HashAuthorizationRequestPayload,
       callbacks,
       config: configV1_3,
       jar: jarV1_3,
@@ -247,7 +253,7 @@ describe("createAuthorizationRequest", () => {
       }),
     );
     expect(result.authorizationRequest).toBe(
-      "https://wallet.example.org/authorize?existing=1&client_id=client-123&request_uri=https%3A%2F%2Frp.example.org%2Frequest.jwt",
+      "https://wallet.example.org/authorize?existing=1&client_id=x509_hash%3Acertificate-hash&request_uri=https%3A%2F%2Frp.example.org%2Frequest.jwt",
     );
   });
 
@@ -319,38 +325,31 @@ describe("createAuthorizationRequest", () => {
     );
   });
 
-  it("creates an openid_federation authorization request with an x5c signer", async () => {
-    vi.mocked(createJarRequest).mockResolvedValue({
-      authorizationRequestJwt: "signed.jwt.value",
-      jarAuthorizationRequest: {
-        client_id: "openid_federation:https://rp.example.org",
-        request_uri: "https://rp.example.org/request.jwt",
-      },
-      signerJwk: {
-        crv: "P-256",
-        kty: "EC",
-        x: "x-value",
-        y: "y-value",
-      },
-    });
-
-    await createAuthorizationRequest({
-      authorizationRequestPayload: openidFederationAuthorizationRequestPayload,
-      callbacks,
-      config: configV1_3,
-      jar: jarV1_3,
-    });
-
-    expect(createJarRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        authorizationRequestHeader: {
-          alg: "ES256",
-          kid: "kid-123",
-          typ: "oauth-authz-req+jwt",
-          x5c: ["leaf-certificate"],
-        },
+  it("rejects openid_federation authorization requests with an x5c signer before JAR creation", async () => {
+    await expect(
+      createAuthorizationRequest({
+        authorizationRequestPayload:
+          openidFederationAuthorizationRequestPayload,
+        callbacks,
+        config: configV1_3,
+        jar: jarV1_3,
       }),
-    );
+    ).rejects.toThrow(Oid4vpError);
+
+    expect(createJarRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects legacy HTTPS authorization requests with an x5c signer before JAR creation", async () => {
+    await expect(
+      createAuthorizationRequest({
+        authorizationRequestPayload: legacyHttpsAuthorizationRequestPayload,
+        callbacks,
+        config: configV1_3,
+        jar: jarV1_3,
+      }),
+    ).rejects.toThrow(Oid4vpError);
+
+    expect(createJarRequest).not.toHaveBeenCalled();
   });
 
   it("rejects x509_hash authorization requests with a federation signer before JAR creation", async () => {

--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -1,11 +1,12 @@
 import { CallbackContext, Oauth2JwtParseError } from "@openid4vc/oauth2";
 import { Jwk } from "@pagopa/io-wallet-oauth2";
 import {
+  HashAlgorithm,
   IoWalletSdkConfig,
   ItWalletSpecsVersion,
   ValidationError,
 } from "@pagopa/io-wallet-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { Oid4vpError, ParseAuthorizeRequestError } from "../../errors";
 import {
@@ -30,6 +31,10 @@ const configV1_0 = new IoWalletSdkConfig({
 
 const configV1_3 = new IoWalletSdkConfig({
   itWalletSpecsVersion: ItWalletSpecsVersion.V1_3,
+});
+
+const configV1_4 = new IoWalletSdkConfig({
+  itWalletSpecsVersion: ItWalletSpecsVersion.V1_4,
 });
 
 const encodeJwtPart = (value: unknown): string =>
@@ -57,7 +62,7 @@ const validX5cHeader = {
   alg: "ES256",
   kid: "test-kid",
   typ: "oauth-authz-req+jwt",
-  x5c: ["MIIBxxx..."],
+  x5c: [Buffer.from("leaf-certificate").toString("base64")],
 };
 
 const wrongSignature =
@@ -125,6 +130,20 @@ const x509RequestObject: Openid4vpAuthorizationRequestPayload = {
   iss: "x509_hash:test-client-id",
 };
 
+const x509RequestObjectWithMatchingHash: Openid4vpAuthorizationRequestPayload =
+  {
+    ...correctRequestObject,
+    client_id: "x509_hash:AQID",
+    iss: "x509_hash:AQID",
+  };
+
+const x509RequestObjectWithMismatchingHash: Openid4vpAuthorizationRequestPayload =
+  {
+    ...correctRequestObject,
+    client_id: "x509_hash:mismatching-hash",
+    iss: "x509_hash:mismatching-hash",
+  };
+
 const correctRequestObjectJwt = createJwt({
   header: validFederationHeader,
   payload: correctRequestObject,
@@ -167,12 +186,28 @@ const x509RequestObjectJwt = createJwt({
   signature: "valid_x509_signature",
 });
 
-// V1_3 header for openid_federation / no-prefix without trust_chain (delegation scenario)
+const x509RequestObjectWithMatchingHashJwt = createJwt({
+  header: validX5cHeader,
+  payload: x509RequestObjectWithMatchingHash,
+  signature: "valid_x509_signature",
+});
+
+const x509RequestObjectWithMismatchingHashJwt = createJwt({
+  header: validX5cHeader,
+  payload: x509RequestObjectWithMismatchingHash,
+  signature: "valid_x509_signature",
+});
+
+// V1_3 header for openid_federation / no-prefix without trust_chain or x5c (delegation scenario)
 const v1_3FederationHeaderNoTrustChain = {
   alg: "ES256",
   kid: "test-kid",
   typ: "oauth-authz-req+jwt",
-  x5c: ["MIIBxxx..."],
+};
+
+const v1_3FederationHeaderWithX5c = {
+  ...v1_3FederationHeaderNoTrustChain,
+  x5c: [Buffer.from("openid federation leaf").toString("base64")],
 };
 
 const v1_3FederationNoTrustChainJwt = createJwt({
@@ -187,6 +222,36 @@ const v1_3FederationClientIdNoTrustChainJwt = createJwt({
     ...correctRequestObject,
     client_id: "openid_federation:test-client-id",
     iss: "openid_federation:test-client-id",
+  },
+  signature: "valid_signature",
+});
+
+const v1_3FederationClientIdWithX5cJwt = createJwt({
+  header: v1_3FederationHeaderWithX5c,
+  payload: {
+    ...correctRequestObject,
+    client_id: "openid_federation:test-client-id",
+    iss: "openid_federation:test-client-id",
+  },
+  signature: "valid_signature",
+});
+
+const legacyHttpsClientIdWithX5cJwt = createJwt({
+  header: v1_3FederationHeaderWithX5c,
+  payload: {
+    ...correctRequestObject,
+    client_id: "https://client.example.it",
+    iss: "https://client.example.it",
+  },
+  signature: "valid_signature",
+});
+
+const legacyHttpsClientIdWithoutX5cJwt = createJwt({
+  header: v1_3FederationHeaderNoTrustChain,
+  payload: {
+    ...correctRequestObject,
+    client_id: "https://client.example.it",
+    iss: "https://client.example.it",
   },
   signature: "valid_signature",
 });
@@ -265,6 +330,11 @@ const callbacks: Pick<CallbackContext, "verifyJwt"> = {
 
     return { verified: false };
   },
+};
+
+const hashCallbacks = {
+  ...callbacks,
+  hash: vi.fn(async () => new Uint8Array([1, 2, 3])),
 };
 
 describe("parseAuthorizationRequest tests", () => {
@@ -422,7 +492,7 @@ describe("parseAuthorizationRequest tests", () => {
     expect(actualRequestObject.header.x5c).toBeDefined();
   });
 
-  it("should throw a ValidationError for x509_hash client_id with missing x5c in header", async () => {
+  it("should throw a ParseAuthorizeRequestError for x509_hash client_id with missing x5c in header", async () => {
     await expect(
       async () =>
         await parseAuthorizeRequest({
@@ -430,9 +500,11 @@ describe("parseAuthorizationRequest tests", () => {
           config: configV1_3,
           requestObjectJwt: x509RequestObjectMissingX5cJwt,
         }),
-    ).rejects.toThrow(ValidationError);
+    ).rejects.toThrow(ParseAuthorizeRequestError);
   });
+});
 
+describe("parseAuthorizationRequest V1_3 and V1_4 x5c binding", () => {
   it("should parse V1_3 request with no-prefix client_id and no trust_chain, delegating to verifyJwt", async () => {
     const result = await parseAuthorizeRequest({
       callbacks,
@@ -441,6 +513,7 @@ describe("parseAuthorizationRequest tests", () => {
     });
     expect(result.payload).toEqual(correctRequestObject);
     expect(result.header.trust_chain).toBeUndefined();
+    expect(result.header.x5c).toBeUndefined();
   });
 
   it("should parse V1_3 request with openid_federation client_id and no trust_chain, delegating to verifyJwt", async () => {
@@ -450,6 +523,104 @@ describe("parseAuthorizationRequest tests", () => {
       requestObjectJwt: v1_3FederationClientIdNoTrustChainJwt,
     });
     expect(result.header.trust_chain).toBeUndefined();
+    expect(result.header.x5c).toBeUndefined();
+  });
+
+  it("should parse V1_4 request with openid_federation client_id and no x5c", async () => {
+    const result = await parseAuthorizeRequest({
+      callbacks,
+      config: configV1_4,
+      requestObjectJwt: v1_3FederationClientIdNoTrustChainJwt,
+    });
+
+    expect(result.header.x5c).toBeUndefined();
+  });
+
+  it("should verify openid_federation without x5c through federation", async () => {
+    const verifyJwt = vi.fn(callbacks.verifyJwt);
+
+    await parseAuthorizeRequest({
+      callbacks: { verifyJwt },
+      config: configV1_3,
+      requestObjectJwt: v1_3FederationClientIdNoTrustChainJwt,
+    });
+
+    expect(verifyJwt).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "federation" }),
+      expect.any(Object),
+    );
+  });
+
+  it("should verify openid_federation with x5c through x5c", async () => {
+    const verifyJwt = vi.fn(callbacks.verifyJwt);
+
+    await parseAuthorizeRequest({
+      callbacks: { verifyJwt },
+      config: configV1_3,
+      requestObjectJwt: v1_3FederationClientIdWithX5cJwt,
+    });
+
+    expect(verifyJwt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "x5c",
+        x5c: v1_3FederationHeaderWithX5c.x5c,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("should verify legacy HTTPS client_id with x5c through x5c", async () => {
+    const verifyJwt = vi.fn(callbacks.verifyJwt);
+
+    await parseAuthorizeRequest({
+      callbacks: { verifyJwt },
+      config: configV1_3,
+      requestObjectJwt: legacyHttpsClientIdWithX5cJwt,
+    });
+
+    expect(verifyJwt).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "x5c" }),
+      expect.any(Object),
+    );
+  });
+
+  it("should verify legacy HTTPS client_id without x5c through federation", async () => {
+    const verifyJwt = vi.fn(callbacks.verifyJwt);
+
+    await parseAuthorizeRequest({
+      callbacks: { verifyJwt },
+      config: configV1_3,
+      requestObjectJwt: legacyHttpsClientIdWithoutX5cJwt,
+    });
+
+    expect(verifyJwt).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "federation" }),
+      expect.any(Object),
+    );
+  });
+
+  it("should accept x509_hash when the hash callback matches the leaf certificate", async () => {
+    const result = await parseAuthorizeRequest({
+      callbacks: hashCallbacks,
+      config: configV1_3,
+      requestObjectJwt: x509RequestObjectWithMatchingHashJwt,
+    });
+
+    expect(result.payload).toEqual(x509RequestObjectWithMatchingHash);
+    expect(hashCallbacks.hash).toHaveBeenCalledWith(
+      expect.any(Uint8Array),
+      HashAlgorithm.Sha256,
+    );
+  });
+
+  it("should reject x509_hash when the hash callback does not match the leaf certificate", async () => {
+    await expect(
+      parseAuthorizeRequest({
+        callbacks: hashCallbacks,
+        config: configV1_3,
+        requestObjectJwt: x509RequestObjectWithMismatchingHashJwt,
+      }),
+    ).rejects.toThrow(ParseAuthorizeRequestError);
   });
 });
 
@@ -488,6 +659,15 @@ describe("parseAuthorizeRequest - optional verification", () => {
 
     expect(result.payload).toEqual(x509RequestObject);
     expect(result.header.x5c).toBeDefined();
+  });
+
+  it("should reject x509_hash without x5c even when verification is disabled", async () => {
+    await expect(
+      parseAuthorizeRequest({
+        config: configV1_3,
+        requestObjectJwt: x509RequestObjectMissingX5cJwt,
+      }),
+    ).rejects.toThrow(ParseAuthorizeRequestError);
   });
 
   it("should accept wrongly signed JWT when verification is disabled", async () => {

--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -552,7 +552,7 @@ describe("parseAuthorizationRequest V1_3 and V1_4 x5c binding", () => {
     );
   });
 
-  it("should verify openid_federation with x5c through x5c", async () => {
+  it("should verify openid_federation with x5c through federation", async () => {
     const verifyJwt = vi.fn(callbacks.verifyJwt);
 
     await parseAuthorizeRequest({
@@ -563,14 +563,13 @@ describe("parseAuthorizationRequest V1_3 and V1_4 x5c binding", () => {
 
     expect(verifyJwt).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "x5c",
-        x5c: v1_3FederationHeaderWithX5c.x5c,
+        method: "federation",
       }),
       expect.any(Object),
     );
   });
 
-  it("should verify legacy HTTPS client_id with x5c through x5c", async () => {
+  it("should verify legacy HTTPS client_id with x5c through federation", async () => {
     const verifyJwt = vi.fn(callbacks.verifyJwt);
 
     await parseAuthorizeRequest({
@@ -580,7 +579,7 @@ describe("parseAuthorizationRequest V1_3 and V1_4 x5c binding", () => {
     });
 
     expect(verifyJwt).toHaveBeenCalledWith(
-      expect.objectContaining({ method: "x5c" }),
+      expect.objectContaining({ method: "federation" }),
       expect.any(Object),
     );
   });

--- a/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/parse-authorization-request.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Oid4vpError, ParseAuthorizeRequestError } from "../../errors";
 import {
   ClientIdPrefix,
+  createX509HashClientId,
   extractClientIdPrefix,
   parseAuthorizeRequest,
 } from "../parse-authorization-request";
@@ -714,6 +715,32 @@ describe("parseAuthorizeRequest - optional verification", () => {
 });
 
 describe("extractClientIdPrefix", () => {
+  it("creates an x509_hash client_id from the x5c leaf certificate using the hash callback", async () => {
+    const hash = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    const leafCertificate = Buffer.from("leaf-certificate").toString("base64");
+
+    await expect(
+      createX509HashClientId({
+        certificateChain: [leafCertificate, "intermediate-certificate"],
+        hash,
+      }),
+    ).resolves.toBe("x509_hash:AQID");
+
+    expect(hash).toHaveBeenCalledWith(
+      new Uint8Array(Buffer.from("leaf-certificate")),
+      HashAlgorithm.Sha256,
+    );
+  });
+
+  it("rejects empty certificate chains when creating an x509_hash client_id", async () => {
+    await expect(
+      createX509HashClientId({
+        certificateChain: [],
+        hash: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      }),
+    ).rejects.toThrow(ParseAuthorizeRequestError);
+  });
+
   it("returns X509_HASH prefix and clean clientId for x509_hash scheme", () => {
     expect(extractClientIdPrefix("x509_hash:abc123")).toEqual({
       clientId: "abc123",

--- a/packages/oid4vp/src/authorization-request/__tests__/z-request-object.test.ts
+++ b/packages/oid4vp/src/authorization-request/__tests__/z-request-object.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { zOpenid4vpAuthorizationRequestPayload } from "../z-authorization-request";
+import {
+  zOpenid4vpAuthorizationRequestHeaderV1_0,
+  zOpenid4vpAuthorizationRequestHeaderV1_3,
+  zOpenid4vpAuthorizationRequestPayload,
+} from "../z-authorization-request";
 
 const basePayload = {
   client_id: "https://verifier.example.com",
@@ -52,6 +56,50 @@ describe("zOpenid4vpAuthorizationRequestPayload", () => {
       response_type: basePayload.response_type,
       state: basePayload.state,
     });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("zOpenid4vpAuthorizationRequestHeader", () => {
+  it("should accept V1_3 headers with x5c", () => {
+    const result = zOpenid4vpAuthorizationRequestHeaderV1_3.safeParse({
+      alg: "ES256",
+      kid: "kid-123",
+      typ: "oauth-authz-req+jwt",
+      x5c: ["leaf-certificate"],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept V1_3 headers without x5c", () => {
+    const result = zOpenid4vpAuthorizationRequestHeaderV1_3.safeParse({
+      alg: "ES256",
+      kid: "kid-123",
+      typ: "oauth-authz-req+jwt",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject V1_3 headers with an empty x5c chain", () => {
+    const result = zOpenid4vpAuthorizationRequestHeaderV1_3.safeParse({
+      alg: "ES256",
+      kid: "kid-123",
+      typ: "oauth-authz-req+jwt",
+      x5c: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("should keep trust_chain mandatory for V1_0 headers", () => {
+    const result = zOpenid4vpAuthorizationRequestHeaderV1_0.safeParse({
+      alg: "ES256",
+      kid: "kid-123",
+      typ: "oauth-authz-req+jwt",
+    });
+
     expect(result.success).toBe(false);
   });
 });

--- a/packages/oid4vp/src/authorization-request/client-id-prefix.ts
+++ b/packages/oid4vp/src/authorization-request/client-id-prefix.ts
@@ -1,0 +1,91 @@
+import {
+  HashAlgorithm,
+  type HashCallback,
+  decodeBase64,
+  encodeToBase64Url,
+} from "@pagopa/io-wallet-utils";
+
+import { Oid4vpError, ParseAuthorizeRequestError } from "../errors";
+import {
+  Openid4vpAuthorizationRequestHeaderV1_3,
+  Openid4vpAuthorizationRequestPayload,
+} from "./z-authorization-request";
+
+export enum ClientIdPrefix {
+  NONE = "none",
+  OPENID_FEDERATION = "openid_federation",
+  X509_HASH = "x509_hash",
+}
+
+export interface ClientIdParts {
+  clientId: string;
+  prefix: ClientIdPrefix;
+}
+
+export function extractClientIdPrefix(clientId: string): ClientIdParts {
+  const colonIndex = clientId.indexOf(":");
+
+  if (colonIndex === -1) {
+    return { clientId, prefix: ClientIdPrefix.NONE };
+  }
+
+  if (clientId.startsWith("https://") || clientId.startsWith("http://")) {
+    return { clientId, prefix: ClientIdPrefix.NONE };
+  }
+
+  const rawPrefix = clientId.slice(0, colonIndex);
+  const rest = clientId.slice(colonIndex + 1);
+
+  if (rawPrefix === ClientIdPrefix.X509_HASH) {
+    return { clientId: rest, prefix: ClientIdPrefix.X509_HASH };
+  }
+  if (rawPrefix === ClientIdPrefix.OPENID_FEDERATION) {
+    return { clientId: rest, prefix: ClientIdPrefix.OPENID_FEDERATION };
+  }
+
+  throw new Oid4vpError(
+    `Unsupported client_id prefix "${rawPrefix}": only "openid_federation" and "x509_hash" are allowed by the IT-Wallet profile`,
+  );
+}
+
+export async function validateAuthorizationRequestClientBinding(options: {
+  hash?: HashCallback;
+  header: Openid4vpAuthorizationRequestHeaderV1_3;
+  payload: Openid4vpAuthorizationRequestPayload;
+}): Promise<ClientIdParts> {
+  const clientIdParts = extractClientIdPrefix(options.payload.client_id);
+
+  if (clientIdParts.prefix !== ClientIdPrefix.X509_HASH) {
+    return clientIdParts;
+  }
+
+  const { x5c } = options.header;
+  if (!Array.isArray(x5c) || x5c.length === 0) {
+    throw new ParseAuthorizeRequestError(
+      "x5c is required in JWT header for x509_hash client_id",
+    );
+  }
+
+  if (!options.hash) {
+    return clientIdParts;
+  }
+
+  const leafCertificate = x5c[0];
+  if (!leafCertificate) {
+    throw new ParseAuthorizeRequestError(
+      "x5c is required in JWT header for x509_hash client_id",
+    );
+  }
+
+  const expectedCertificateHash = encodeToBase64Url(
+    await options.hash(decodeBase64(leafCertificate), HashAlgorithm.Sha256),
+  );
+
+  if (expectedCertificateHash !== clientIdParts.clientId) {
+    throw new ParseAuthorizeRequestError(
+      "x509_hash client_id does not match the JWT header leaf certificate",
+    );
+  }
+
+  return clientIdParts;
+}

--- a/packages/oid4vp/src/authorization-request/client-id-prefix.ts
+++ b/packages/oid4vp/src/authorization-request/client-id-prefix.ts
@@ -22,6 +22,11 @@ export interface ClientIdParts {
   prefix: ClientIdPrefix;
 }
 
+export interface CreateX509HashClientIdOptions {
+  certificateChain: string[];
+  hash: HashCallback;
+}
+
 export function extractClientIdPrefix(clientId: string): ClientIdParts {
   const colonIndex = clientId.indexOf(":");
 
@@ -48,6 +53,22 @@ export function extractClientIdPrefix(clientId: string): ClientIdParts {
   );
 }
 
+export async function createX509HashClientId(
+  options: CreateX509HashClientIdOptions,
+): Promise<string> {
+  return `${ClientIdPrefix.X509_HASH}:${await calculateX509CertificateHash(options)}`;
+}
+
+async function calculateX509CertificateHash(
+  options: CreateX509HashClientIdOptions,
+) {
+  const leafCertificate = getLeafCertificate(options.certificateChain);
+
+  return encodeToBase64Url(
+    await options.hash(decodeBase64(leafCertificate), HashAlgorithm.Sha256),
+  );
+}
+
 export async function validateAuthorizationRequestClientBinding(options: {
   hash?: HashCallback;
   header: Openid4vpAuthorizationRequestHeaderV1_3;
@@ -70,16 +91,10 @@ export async function validateAuthorizationRequestClientBinding(options: {
     return clientIdParts;
   }
 
-  const leafCertificate = x5c[0];
-  if (!leafCertificate) {
-    throw new ParseAuthorizeRequestError(
-      "x5c is required in JWT header for x509_hash client_id",
-    );
-  }
-
-  const expectedCertificateHash = encodeToBase64Url(
-    await options.hash(decodeBase64(leafCertificate), HashAlgorithm.Sha256),
-  );
+  const expectedCertificateHash = await calculateX509CertificateHash({
+    certificateChain: x5c,
+    hash: options.hash,
+  });
 
   if (expectedCertificateHash !== clientIdParts.clientId) {
     throw new ParseAuthorizeRequestError(
@@ -88,4 +103,16 @@ export async function validateAuthorizationRequestClientBinding(options: {
   }
 
   return clientIdParts;
+}
+
+function getLeafCertificate(certificateChain: string[]) {
+  const leafCertificate = certificateChain[0];
+
+  if (!leafCertificate) {
+    throw new ParseAuthorizeRequestError(
+      "Certificate chain is empty, cannot validate x509_hash",
+    );
+  }
+
+  return leafCertificate;
 }

--- a/packages/oid4vp/src/authorization-request/create-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/create-authorization-request.ts
@@ -59,7 +59,7 @@ interface BaseCreateAuthorizationRequestOptions<
    * Required callbacks used to create a signed/encrypted Request Object.
    */
   callbacks: Partial<Pick<CallbackContext, "encryptJwe">> &
-    Pick<CallbackContext, "hash"> &
+    Partial<Pick<CallbackContext, "hash">> &
     Pick<CallbackContext, "signJwt">;
 
   config: IoWalletSdkConfig<V>;

--- a/packages/oid4vp/src/authorization-request/create-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/create-authorization-request.ts
@@ -266,4 +266,13 @@ function validateJarSignerForAuthorizationRequest(
       "x509_hash client_id requires a JAR signer with method x5c",
     );
   }
+
+  if (
+    prefix !== ClientIdPrefix.X509_HASH &&
+    jwtSigner.method !== "federation"
+  ) {
+    throw new Oid4vpError(
+      "openid_federation and legacy client_id values require a JAR signer with method federation",
+    );
+  }
 }

--- a/packages/oid4vp/src/authorization-request/create-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/create-authorization-request.ts
@@ -19,6 +19,7 @@ import {
 } from "@pagopa/io-wallet-utils";
 
 import { Oid4vpError } from "../errors";
+import { ClientIdPrefix, extractClientIdPrefix } from "./client-id-prefix";
 import {
   Openid4vpAuthorizationRequestPayload,
   zOpenid4vpAuthorizationRequestHeaderV1_0,
@@ -35,7 +36,7 @@ type BaseJarOptions<TSigner extends JwtSignerFederation | JwtSignerX5c> = {
 
 export type JarOptionsV1_0 = BaseJarOptions<JwtSignerFederation>;
 
-export type JarOptionsV1_3 = BaseJarOptions<JwtSignerX5c>;
+export type JarOptionsV1_3 = BaseJarOptions<JwtSignerFederation | JwtSignerX5c>;
 
 export type JarOptionsV1_4 = JarOptionsV1_3;
 
@@ -143,7 +144,7 @@ const dispatchCreateAuthorizationRequest = createVersionDispatcher<
       o as CreateAuthorizationRequestOptionsV1_3,
       zOpenid4vpAuthorizationRequestHeaderV1_3,
     ),
-  // V1_4 reuses V1_3 JAR header schema (alg, typ, kid, trust_chain, x5c) — no breaking changes.
+  // V1_4 reuses the V1_3 JAR header schema; the conditional x5c rule is a normative 1.4.4 LTS backport.
   [ItWalletSpecsVersion.V1_4]: async (o) =>
     createAuthorizationRequestWithHeader(
       o as CreateAuthorizationRequestOptionsV1_4,
@@ -204,6 +205,12 @@ async function createAuthorizationRequestWithHeader<TJar extends JarOptions>(
     options.authorizationRequestPayload,
   );
 
+  validateJarSignerForAuthorizationRequest(
+    options.config.itWalletSpecsVersion,
+    jar.jwtSigner,
+    authorizationRequestPayload,
+  );
+
   const additionalJwtPayload = !jar.additionalJwtPayload?.aud
     ? { ...jar.additionalJwtPayload, aud: jar.requestUri }
     : jar.additionalJwtPayload;
@@ -241,4 +248,22 @@ function createAuthorizationRequestUrl(
   url.search = searchParams.toString();
 
   return url.toString();
+}
+
+function validateJarSignerForAuthorizationRequest(
+  specsVersion: ItWalletSpecsVersion,
+  jwtSigner: JwtSignerFederation | JwtSignerX5c,
+  payload: Openid4vpAuthorizationRequestPayload,
+) {
+  if (specsVersion === ItWalletSpecsVersion.V1_0) {
+    return;
+  }
+
+  const { prefix } = extractClientIdPrefix(payload.client_id);
+
+  if (prefix === ClientIdPrefix.X509_HASH && jwtSigner.method !== "x5c") {
+    throw new Oid4vpError(
+      "x509_hash client_id requires a JAR signer with method x5c",
+    );
+  }
 }

--- a/packages/oid4vp/src/authorization-request/create-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/create-authorization-request.ts
@@ -19,7 +19,11 @@ import {
 } from "@pagopa/io-wallet-utils";
 
 import { Oid4vpError } from "../errors";
-import { ClientIdPrefix, extractClientIdPrefix } from "./client-id-prefix";
+import {
+  ClientIdPrefix,
+  extractClientIdPrefix,
+  validateAuthorizationRequestClientBinding,
+} from "./client-id-prefix";
 import {
   Openid4vpAuthorizationRequestPayload,
   zOpenid4vpAuthorizationRequestHeaderV1_0,
@@ -55,6 +59,7 @@ interface BaseCreateAuthorizationRequestOptions<
    * Required callbacks used to create a signed/encrypted Request Object.
    */
   callbacks: Partial<Pick<CallbackContext, "encryptJwe">> &
+    Pick<CallbackContext, "hash"> &
     Pick<CallbackContext, "signJwt">;
 
   config: IoWalletSdkConfig<V>;
@@ -210,6 +215,12 @@ async function createAuthorizationRequestWithHeader<TJar extends JarOptions>(
     jar.jwtSigner,
     authorizationRequestPayload,
   );
+
+  validateAuthorizationRequestClientBinding({
+    hash: options.callbacks.hash,
+    header: authorizationRequestHeader,
+    payload: authorizationRequestPayload,
+  });
 
   const additionalJwtPayload = !jar.additionalJwtPayload?.aud
     ? { ...jar.additionalJwtPayload, aud: jar.requestUri }

--- a/packages/oid4vp/src/authorization-request/fetch-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/fetch-authorization-request.ts
@@ -8,6 +8,10 @@ import {
 
 import { Oid4vpError } from "../errors";
 import { validateAuthorizationRequestParams } from "./validate-authorization-request";
+import {
+  X509CertificateBinding,
+  validateCertificateEndpoints,
+} from "./validate-certificate-endpoints";
 import { zAuthorizationRequestUrlParams } from "./z-authorization-request-url";
 
 export interface FetchAuthorizationRequestOptions {
@@ -43,6 +47,14 @@ export interface FetchAuthorizationRequestOptions {
    * Optional wallet nonce for replay attack prevention (RECOMMENDED per spec)
    */
   walletNonce?: string;
+
+  /**
+   * Optional RP certificate context used to bind `request_uri` to the certificate SAN entries.
+   */
+  x509Certificate?: {
+    binding: X509CertificateBinding;
+    leafCertificate: string;
+  };
 }
 
 export interface ParsedQrCode {
@@ -222,6 +234,19 @@ export async function fetchAuthorizationRequest(
     if (validatedParams.request) {
       requestObjectJwt = validatedParams.request;
     } else {
+      if (options.x509Certificate) {
+        await validateCertificateEndpoints({
+          callbacks: options.x509Certificate.binding,
+          certificate: options.x509Certificate.leafCertificate,
+          endpoints: [
+            {
+              name: "request_uri",
+              uri: validatedParams.request_uri,
+            },
+          ],
+        });
+      }
+
       // Type system guarantees request_uri is defined here due to validation
       requestObjectJwt = await fetchRequestObjectJwt(
         validatedParams.request_uri as string,

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -43,10 +43,11 @@ export {
  * Retrieves the public key for verifying the Request Object JWT signature
  * according to IT Wallet specifications.
  *
- * Priority order:
- * 1. If x5c is present: use x5c certificate chain from header.
- * 2. Otherwise return a federation signer; if trust_chain is present it is forwarded,
- *    otherwise the verifyJwt callback is responsible for reconstructing the chain from client_id.
+ * Prefix routing:
+ * 1. If client_id uses x509_hash: use x5c certificate chain from header.
+ * 2. If client_id uses openid_federation or no prefix: return a federation signer;
+ *    if trust_chain is present it is forwarded, otherwise the verifyJwt callback is
+ *    responsible for reconstructing the chain from client_id.
  *
  * @param options - Parse options containing decoded JWT
  * @returns The JWK to use for signature verification
@@ -59,16 +60,6 @@ function getPublicKeyForVerification(options: {
   const { header, payload } = options;
 
   const { prefix: clientIdPrefix } = extractClientIdPrefix(payload.client_id);
-
-  if (Array.isArray(header.x5c) && header.x5c.length > 0) {
-    return {
-      alg: header.alg,
-      kid: header.kid,
-      method: "x5c" as const,
-      ...(header.trust_chain && { trustChain: header.trust_chain }),
-      x5c: header.x5c,
-    };
-  }
 
   if (
     clientIdPrefix === ClientIdPrefix.OPENID_FEDERATION ||
@@ -85,6 +76,22 @@ function getPublicKeyForVerification(options: {
       kid: header.kid,
       method: "federation" as const,
       ...(header.trust_chain && { trustChain: header.trust_chain }),
+    };
+  }
+
+  if (clientIdPrefix === ClientIdPrefix.X509_HASH) {
+    if (!Array.isArray(header.x5c) || header.x5c.length === 0) {
+      throw new ParseAuthorizeRequestError(
+        "x5c is required in JWT header for x509_hash client_id",
+      );
+    }
+
+    return {
+      alg: header.alg,
+      kid: header.kid,
+      method: "x5c" as const,
+      ...(header.trust_chain && { trustChain: header.trust_chain }),
+      x5c: header.x5c,
     };
   }
 
@@ -135,8 +142,8 @@ export interface ParsedAuthorizeRequestResult {
  * This method decodes the Request Object JWT and validates its structure. If the `verifyJwt`
  * callback is provided, it also verifies the JWT signature using the public key obtained
  * according to IT Wallet specifications:
- * 1. If x5c is present: pass an x5c signer to the callback.
- * 2. Otherwise, for openid_federation and legacy HTTPS client identifiers, pass a federation signer;
+ * 1. If client_id uses x509_hash: pass an x5c signer to the callback.
+ * 2. If client_id uses openid_federation or a legacy HTTPS identifier, pass a federation signer;
  *    trust_chain is forwarded when present, otherwise the callback must reconstruct the chain from client_id.
  *
  * For x509_hash client identifiers, x5c is always required. When `callbacks.hash` is provided,

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -33,8 +33,8 @@ import {
 } from "./z-authorization-request";
 
 export {
+  type ClientIdParts,
   ClientIdPrefix,
-  ClientIdParts,
   createX509HashClientId,
   extractClientIdPrefix,
 } from "./client-id-prefix";
@@ -103,8 +103,8 @@ function getPublicKeyForVerification(options: {
 
 export interface ParseAuthorizeRequestOptions {
   /**
-   * Optional callback context for JWT signature verification.
-   * If not provided, signature verification is skipped.
+   * Optional callback context for JWT signature verification and hashing x509 client_id for digest comparison.
+   * If not provided, signature verification is skipped or hash skips the x509_hash digest comparison.
    */
   callbacks?: Partial<Pick<CallbackContext, "hash" | "verifyJwt">> &
     Partial<X509CertificateBinding>;

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -34,6 +34,7 @@ import {
 
 export {
   ClientIdPrefix,
+  ClientIdParts,
   createX509HashClientId,
   extractClientIdPrefix,
 } from "./client-id-prefix";

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -15,72 +15,33 @@ import {
 
 import { Oid4vpError, ParseAuthorizeRequestError } from "../errors";
 import {
+  ClientIdPrefix,
+  extractClientIdPrefix,
+  validateAuthorizationRequestClientBinding,
+} from "./client-id-prefix";
+import {
+  X509CertificateBinding,
+  validateCertificateEndpoints,
+} from "./validate-certificate-endpoints";
+import {
   Openid4vpAuthorizationRequestHeader,
+  Openid4vpAuthorizationRequestHeaderV1_3,
   Openid4vpAuthorizationRequestPayload,
   zOpenid4vpAuthorizationRequestHeaderV1_0,
   zOpenid4vpAuthorizationRequestHeaderV1_3,
   zOpenid4vpAuthorizationRequestPayload,
 } from "./z-authorization-request";
 
-/**
- * Enum representing the client_id prefix types according to IT Wallet specifications
- */
-export enum ClientIdPrefix {
-  NONE = "none",
-  OPENID_FEDERATION = "openid_federation",
-  X509_HASH = "x509_hash",
-}
-
-export interface ClientIdParts {
-  clientId: string;
-  prefix: ClientIdPrefix;
-}
-
-/**
- * Extracts the prefix and clean clientId from a client_id string.
- * Only the IT-Wallet profile schemes (`openid_federation`, `x509_hash`) and the
- * prefix-less form are accepted; any other prefix causes an error.
- * @param clientId - The client_id from the request object
- * @returns A {@link ClientIdParts} object with the resolved prefix and unprefixed clientId
- * @throws {Oid4vpError} When the prefix does not match a supported IT-Wallet scheme
- */
-export function extractClientIdPrefix(clientId: string): ClientIdParts {
-  const colonIndex = clientId.indexOf(":");
-
-  // No colon → no prefix
-  if (colonIndex === -1) {
-    return { clientId, prefix: ClientIdPrefix.NONE };
-  }
-
-  // Explicitly allow HTTP(S) URL client_id values without treating the scheme as a prefix.
-  if (clientId.startsWith("https://") || clientId.startsWith("http://")) {
-    return { clientId, prefix: ClientIdPrefix.NONE };
-  }
-
-  const rawPrefix = clientId.slice(0, colonIndex);
-  const rest = clientId.slice(colonIndex + 1);
-
-  if (rawPrefix === ClientIdPrefix.X509_HASH) {
-    return { clientId: rest, prefix: ClientIdPrefix.X509_HASH };
-  }
-  if (rawPrefix === ClientIdPrefix.OPENID_FEDERATION) {
-    return { clientId: rest, prefix: ClientIdPrefix.OPENID_FEDERATION };
-  }
-
-  throw new Oid4vpError(
-    `Unsupported client_id prefix "${rawPrefix}": only "openid_federation" and "x509_hash" are allowed by the IT-Wallet profile`,
-  );
-}
+export { ClientIdPrefix, extractClientIdPrefix } from "./client-id-prefix";
 
 /**
  * Retrieves the public key for verifying the Request Object JWT signature
  * according to IT Wallet specifications.
  *
  * Priority order:
- * 1. If client_id has x509_hash prefix: use x5c certificate chain from header
- * 2. If client_id has openid_federation prefix or no prefix: return a federation signer; if trust_chain
- *    is present it is forwarded, otherwise the verifyJwt callback is responsible for reconstructing
- *    the chain from client_id
+ * 1. If x5c is present: use x5c certificate chain from header.
+ * 2. Otherwise return a federation signer; if trust_chain is present it is forwarded,
+ *    otherwise the verifyJwt callback is responsible for reconstructing the chain from client_id.
  *
  * @param options - Parse options containing decoded JWT
  * @returns The JWK to use for signature verification
@@ -94,24 +55,16 @@ function getPublicKeyForVerification(options: {
 
   const { prefix: clientIdPrefix } = extractClientIdPrefix(payload.client_id);
 
-  // Priority 1: x509_hash prefix - use x5c certificate chain from header
-  if (clientIdPrefix === ClientIdPrefix.X509_HASH) {
-    if (!Array.isArray(header.x5c) || header.x5c.length === 0) {
-      throw new ParseAuthorizeRequestError(
-        "x5c is required in JWT header for x509_hash client_id",
-      );
-    }
-
+  if (Array.isArray(header.x5c) && header.x5c.length > 0) {
     return {
       alg: header.alg,
       kid: header.kid,
       method: "x5c" as const,
+      ...(header.trust_chain && { trustChain: header.trust_chain }),
       x5c: header.x5c,
     };
   }
 
-  // Priority 2: openid_federation prefix or no prefix - use trust_chain if present,
-  // otherwise delegate chain reconstruction to the verifyJwt callback
   if (
     clientIdPrefix === ClientIdPrefix.OPENID_FEDERATION ||
     clientIdPrefix === ClientIdPrefix.NONE
@@ -131,7 +84,7 @@ function getPublicKeyForVerification(options: {
   }
 
   throw new ParseAuthorizeRequestError(
-    "Unable to determine public key for Request Object verification",
+    "Unable to determine public key for Request Object verification with client_id prefix: " + clientIdPrefix,
   );
 }
 
@@ -140,7 +93,8 @@ export interface ParseAuthorizeRequestOptions {
    * Optional callback context for JWT signature verification.
    * If not provided, signature verification is skipped.
    */
-  callbacks?: Pick<CallbackContext, "verifyJwt">;
+  callbacks?: Partial<Pick<CallbackContext, "hash" | "verifyJwt">> &
+    Partial<X509CertificateBinding>;
 
   config: IoWalletSdkConfig;
 
@@ -159,6 +113,14 @@ export interface ParsedAuthorizeRequestResult {
    * The parsed authorization request object.
    */
   payload: Openid4vpAuthorizationRequestPayload;
+
+  /**
+   * X.509 context extracted from the Request Object header when `x5c` is present.
+   */
+  x509Certificate?: {
+    leafCertificate: string;
+    x5c: [string, ...string[]];
+  };
 }
 
 /**
@@ -167,9 +129,12 @@ export interface ParsedAuthorizeRequestResult {
  * This method decodes the Request Object JWT and validates its structure. If the `verifyJwt`
  * callback is provided, it also verifies the JWT signature using the public key obtained
  * according to IT Wallet specifications:
- * 1. If client_id has x509_hash prefix: use x5c certificate chain from header
- * 2. If client_id has openid_federation prefix or no prefix: pass a federation signer to the callback;
- *    trust_chain is forwarded when present, otherwise the callback must reconstruct the chain from client_id
+ * 1. If x5c is present: pass an x5c signer to the callback.
+ * 2. Otherwise, for openid_federation and legacy HTTPS client identifiers, pass a federation signer;
+ *    trust_chain is forwarded when present, otherwise the callback must reconstruct the chain from client_id.
+ *
+ * For x509_hash client identifiers, x5c is always required. When `callbacks.hash` is provided,
+ * this method also checks the SHA-256 base64url certificate digest embedded in client_id.
  *
  * Security: If `verifyJwt` callback is not provided in options, JWT signature verification is skipped.
  *
@@ -202,6 +167,35 @@ export async function parseAuthorizeRequest(
       payloadSchema: zOpenid4vpAuthorizationRequestPayload,
     });
 
+    if (options.config.itWalletSpecsVersion !== ItWalletSpecsVersion.V1_0) {
+      await validateAuthorizationRequestClientBinding({
+        hash: options.callbacks?.hash,
+        header: decoded.header as Openid4vpAuthorizationRequestHeaderV1_3,
+        payload: decoded.payload,
+      });
+    }
+
+    const x5c =
+      "x5c" in decoded.header &&
+      Array.isArray(decoded.header.x5c) &&
+      decoded.header.x5c.length > 0
+        ? (decoded.header.x5c as [string, ...string[]])
+        : undefined;
+
+    if (x5c && options.callbacks?.getX509CertificateMetadata) {
+      await validateCertificateEndpoints({
+        callbacks: {
+          getX509CertificateMetadata:
+            options.callbacks.getX509CertificateMetadata,
+        },
+        certificate: x5c[0],
+        endpoints: [
+          { name: "request_uri", uri: decoded.payload.request_uri },
+          { name: "response_uri", uri: decoded.payload.response_uri },
+        ],
+      });
+    }
+
     if (options.callbacks?.verifyJwt) {
       const signer = getPublicKeyForVerification({
         header: decoded.header,
@@ -221,12 +215,19 @@ export async function parseAuthorizeRequest(
     return {
       header: decoded.header,
       payload: decoded.payload,
+      ...(x5c && {
+        x509Certificate: {
+          leafCertificate: x5c[0],
+          x5c,
+        },
+      }),
     };
   } catch (error) {
     if (
       error instanceof ItWalletSpecsVersionError ||
       error instanceof ValidationError ||
-      error instanceof Oauth2JwtParseError
+      error instanceof Oauth2JwtParseError ||
+      error instanceof Oid4vpError
     )
       throw error;
     throw new ParseAuthorizeRequestError(

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -32,7 +32,11 @@ import {
   zOpenid4vpAuthorizationRequestPayload,
 } from "./z-authorization-request";
 
-export { ClientIdPrefix, extractClientIdPrefix } from "./client-id-prefix";
+export {
+  ClientIdPrefix,
+  createX509HashClientId,
+  extractClientIdPrefix,
+} from "./client-id-prefix";
 
 /**
  * Retrieves the public key for verifying the Request Object JWT signature

--- a/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/parse-authorization-request.ts
@@ -84,7 +84,8 @@ function getPublicKeyForVerification(options: {
   }
 
   throw new ParseAuthorizeRequestError(
-    "Unable to determine public key for Request Object verification with client_id prefix: " + clientIdPrefix,
+    "Unable to determine public key for Request Object verification with client_id prefix: " +
+      clientIdPrefix,
   );
 }
 

--- a/packages/oid4vp/src/authorization-request/validate-certificate-endpoints.ts
+++ b/packages/oid4vp/src/authorization-request/validate-certificate-endpoints.ts
@@ -1,0 +1,99 @@
+import { Oid4vpError } from "../errors";
+
+export interface X509CertificateMetadata {
+  sanDnsNames?: string[];
+  sanUriNames?: string[];
+}
+
+export type GetX509CertificateMetadataCallback = (
+  certificate: string,
+) => Promise<X509CertificateMetadata> | X509CertificateMetadata;
+
+export interface X509CertificateBinding {
+  getX509CertificateMetadata: GetX509CertificateMetadataCallback;
+}
+
+export interface CertificateEndpoint {
+  name: string;
+  uri?: string;
+}
+
+export interface ValidateCertificateEndpointsOptions {
+  callbacks: X509CertificateBinding;
+  certificate: string;
+  endpoints: CertificateEndpoint[];
+}
+
+export async function validateCertificateEndpoints(
+  options: ValidateCertificateEndpointsOptions,
+): Promise<void> {
+  const metadata = await options.callbacks.getX509CertificateMetadata(
+    options.certificate,
+  );
+
+  for (const endpoint of options.endpoints) {
+    if (!endpoint.uri) {
+      continue;
+    }
+
+    validateEndpointAgainstMetadata(
+      { name: endpoint.name, uri: endpoint.uri },
+      metadata,
+    );
+  }
+}
+
+function validateEndpointAgainstMetadata(
+  endpoint: { name: string; uri: string },
+  metadata: X509CertificateMetadata,
+) {
+  const endpointUrl = parseEndpointUrl(endpoint);
+  const sanUriNames = metadata.sanUriNames ?? [];
+
+  if (sanUriNames.length > 0) {
+    const matchesUriSan = sanUriNames.some(
+      (sanUriName) =>
+        normalizeUriForComparison(sanUriName) === endpointUrl.href,
+    );
+
+    if (!matchesUriSan) {
+      throw new Oid4vpError(
+        `${endpoint.name} is not covered by the Relying Party certificate URI SAN entries`,
+      );
+    }
+
+    return;
+  }
+
+  const sanDnsNames = metadata.sanDnsNames ?? [];
+  const matchesDnsSan = sanDnsNames.some(
+    (sanDnsName) => sanDnsName.toLowerCase() === endpointUrl.hostname,
+  );
+
+  if (!matchesDnsSan) {
+    throw new Oid4vpError(
+      `${endpoint.name} is not covered by the Relying Party certificate DNS SAN entries`,
+    );
+  }
+}
+
+function normalizeUriForComparison(uri: string) {
+  try {
+    return new URL(uri).href;
+  } catch (error) {
+    throw new Oid4vpError(`Certificate URI SAN is not a valid URL: ${uri}`, {
+      cause: error,
+    });
+  }
+}
+
+function parseEndpointUrl(endpoint: { name: string; uri: string }) {
+  try {
+    return new URL(endpoint.uri);
+  } catch (error) {
+    throw new Oid4vpError(
+      `${endpoint.name} is not a valid URL: ${endpoint.uri}`,
+      { cause: error },
+    );
+  }
+}

--- a/packages/oid4vp/src/authorization-request/validate-certificate-endpoints.ts
+++ b/packages/oid4vp/src/authorization-request/validate-certificate-endpoints.ts
@@ -49,32 +49,21 @@ function validateEndpointAgainstMetadata(
 ) {
   const endpointUrl = parseEndpointUrl(endpoint);
   const sanUriNames = metadata.sanUriNames ?? [];
+  const matchesUriSan = sanUriNames.some(
+    (sanUriName) => normalizeUriForComparison(sanUriName) === endpointUrl.href,
+  );
+  const sanDnsNames = metadata.sanDnsNames ?? [];
+  const matchesDnsSan = sanDnsNames.some((sanDnsName) =>
+    matchesDnsSanHostname(sanDnsName, endpointUrl.hostname),
+  );
 
-  if (sanUriNames.length > 0) {
-    const matchesUriSan = sanUriNames.some(
-      (sanUriName) =>
-        normalizeUriForComparison(sanUriName) === endpointUrl.href,
-    );
-
-    if (!matchesUriSan) {
-      throw new Oid4vpError(
-        `${endpoint.name} is not covered by the Relying Party certificate URI SAN entries`,
-      );
-    }
-
+  if (matchesUriSan || matchesDnsSan) {
     return;
   }
 
-  const sanDnsNames = metadata.sanDnsNames ?? [];
-  const matchesDnsSan = sanDnsNames.some(
-    (sanDnsName) => sanDnsName.toLowerCase() === endpointUrl.hostname,
+  throw new Oid4vpError(
+    `${endpoint.name} is not covered by the Relying Party certificate SAN entries`,
   );
-
-  if (!matchesDnsSan) {
-    throw new Oid4vpError(
-      `${endpoint.name} is not covered by the Relying Party certificate DNS SAN entries`,
-    );
-  }
 }
 
 function normalizeUriForComparison(uri: string) {
@@ -85,6 +74,34 @@ function normalizeUriForComparison(uri: string) {
       cause: error,
     });
   }
+}
+
+function matchesDnsSanHostname(sanDnsName: string, hostname: string) {
+  const normalizedSanDnsName = sanDnsName.toLowerCase();
+  const normalizedHostname = hostname.toLowerCase();
+
+  if (normalizedSanDnsName === normalizedHostname) {
+    return true;
+  }
+
+  if (!normalizedSanDnsName.includes("*")) {
+    return false;
+  }
+
+  const wildcardCount = [...normalizedSanDnsName].filter(
+    (character) => character === "*",
+  ).length;
+  const sanLabels = normalizedSanDnsName.split(".");
+  const hostnameLabels = normalizedHostname.split(".");
+
+  return (
+    wildcardCount === 1 &&
+    sanLabels[0] === "*" &&
+    sanLabels.length === hostnameLabels.length &&
+    sanLabels
+      .slice(1)
+      .every((label, index) => label === hostnameLabels[index + 1])
+  );
 }
 
 function parseEndpointUrl(endpoint: { name: string; uri: string }) {

--- a/packages/oid4vp/src/authorization-request/z-authorization-request.ts
+++ b/packages/oid4vp/src/authorization-request/z-authorization-request.ts
@@ -75,7 +75,7 @@ export const zOpenid4vpAuthorizationRequestHeaderV1_3 =
   zOpenid4vpAuthorizationRequestHeaderBase
     .extend({
       trust_chain: zTrustChain.optional(),
-      x5c: zCertificateChain,
+      x5c: zCertificateChain.optional(),
     })
     .loose();
 

--- a/packages/oid4vp/src/authorization-response/fetch-authorization-response.ts
+++ b/packages/oid4vp/src/authorization-response/fetch-authorization-response.ts
@@ -9,6 +9,10 @@ import {
   parseWithErrorHandling,
 } from "@pagopa/io-wallet-utils";
 
+import {
+  X509CertificateBinding,
+  validateCertificateEndpoints,
+} from "../authorization-request/validate-certificate-endpoints";
 import { FetchAuthorizationResponseError } from "../errors";
 import {
   Openid4vpAuthorizationResponseResult,
@@ -34,6 +38,16 @@ export interface FetchAuthorizationResponseOptions {
    * The response_uri field contained in the {@link Openid4vpAuthorizationRequestPayload}
    */
   presentationResponseUri: string;
+
+  /**
+   * Optional RP certificate context from the parsed Request Object.
+   * When provided, `presentationResponseUri` and the returned `redirect_uri`
+   * are checked against the certificate SAN entries through the supplied callback.
+   */
+  x509Certificate?: {
+    binding: X509CertificateBinding;
+    leafCertificate: string;
+  };
 }
 
 /**
@@ -50,6 +64,16 @@ export async function fetchAuthorizationResponse(
   options: FetchAuthorizationResponseOptions,
 ): Promise<Openid4vpAuthorizationResponseResult> {
   try {
+    if (options.x509Certificate) {
+      await validateCertificateEndpoints({
+        callbacks: options.x509Certificate.binding,
+        certificate: options.x509Certificate.leafCertificate,
+        endpoints: [
+          { name: "response_uri", uri: options.presentationResponseUri },
+        ],
+      });
+    }
+
     const fetch = createFetcher(options.callbacks.fetch);
     const authorizationResponseResult = await fetch(
       options.presentationResponseUri,
@@ -73,14 +97,30 @@ export async function fetchAuthorizationResponse(
       await authorizationResponseResult.json();
 
     //Response could be anything, so it's returned as is for further processing
-    return parseWithErrorHandling(
+    const parsedAuthorizationResponseResult = parseWithErrorHandling(
       zOpenid4vpAuthorizationResponseResult,
       authorizationResponseResultJson,
     );
+
+    if (options.x509Certificate) {
+      await validateCertificateEndpoints({
+        callbacks: options.x509Certificate.binding,
+        certificate: options.x509Certificate.leafCertificate,
+        endpoints: [
+          {
+            name: "redirect_uri",
+            uri: parsedAuthorizationResponseResult.redirect_uri,
+          },
+        ],
+      });
+    }
+
+    return parsedAuthorizationResponseResult;
   } catch (error) {
     if (
       error instanceof UnexpectedStatusCodeError ||
-      error instanceof ValidationError
+      error instanceof ValidationError ||
+      error instanceof FetchAuthorizationResponseError
     ) {
       throw error;
     }

--- a/packages/oid4vp/src/index.ts
+++ b/packages/oid4vp/src/index.ts
@@ -2,6 +2,7 @@ export * from "./authorization-request/create-authorization-request";
 export * from "./authorization-request/fetch-authorization-request";
 export * from "./authorization-request/parse-authorization-request";
 export * from "./authorization-request/validate-authorization-request";
+export * from "./authorization-request/validate-certificate-endpoints";
 export * from "./authorization-request/z-authorization-request";
 export * from "./authorization-request/z-authorization-request-url";
 export * from "./authorization-response/create-authorization-response";


### PR DESCRIPTION
## Description

This PR backports the **IT-Wallet 1.4.4 LTS conditional `x5c` Request Object rule** to OID4VP SDK profiles `V1_3` and `V1_4`. It allows `openid_federation` client IDs to use federation signers without mandating `x5c` in the header, while retaining strict `x5c` validation for `x509_hash` client IDs.

Additionally, this change introduces X.509 certificate SAN (Subject Alternative Name) endpoint validation for `request_uri`, `response_uri`, and `redirect_uri`.

---

## Key Changes

### 1. Schema & Header Updates
* **Optional `x5c` in `zOpenid4vpAuthorizationRequestHeaderV1_3`**: Updated schema to make `x5c` optional (`zCertificateChain.optional()`), allowing federation-signed Request Objects without an embedded X.509 certificate chain.

### 2. Client ID Prefix & Binding Utilities
* Added `packages/oid4vp/src/authorization-request/client-id-prefix.ts`:
  * **`ClientIdPrefix`**: Enum representing `none`, `openid_federation`, and `x509_hash`.
  * **`extractClientIdPrefix()`**: Parses and validates supported scheme prefixes.
  * **`validateAuthorizationRequestClientBinding()`**: Validates `x509_hash` client IDs against the SHA-256 base64url digest of the leaf certificate in `x5c`.
  * **`createX509HashClientId`**: create clientId value for Authorization Request when x5c is used

### 3. Certificate SAN Endpoint Validation
* Added `packages/oid4vp/src/authorization-request/validate-certificate-endpoints.ts`:
  * Validates that endpoints (`request_uri`, `response_uri`, `redirect_uri`) match the RP certificate's DNS or URI SAN (Subject Alternative Name) entries.
* Integrated into:
  * `fetchAuthorizationRequest`: Validates `request_uri`.
  * `fetchAuthorizationResponse`: Validates `response_uri` before posting and `redirect_uri` after receiving the response.
  * `parseAuthorizeRequest`: Automatically validates `request_uri` and `response_uri` when an `x5c` header and certificate metadata callback are provided.

### 4. Creation & Parsing Logic Updates
* **`createAuthorizationRequest`**:
  * Updated `JarOptionsV1_3` / `JarOptionsV1_4` to accept both `JwtSignerFederation` and `JwtSignerX5c`.
  * Added `validateJarSignerForAuthorizationRequest()` to enforce that `x509_hash` client IDs use an `x5c` signer.
* **`parseAuthorizeRequest`**:
  * Refactored verification key selection (`getPublicKeyForVerification`): Uses `x5c` if present in the header; otherwise falls back to federation verification for `openid_federation` or legacy HTTPS client IDs.
  * Extracts and returns `x509Certificate` context in `ParsedAuthorizeRequestResult` when `x5c` is present.

---

## Testing & Verification

* **Unit Tests**: Updated and added unit test coverage in:
  * `create-authorization-request.test.ts`: Verifies federation and `x5c` signers across V1_3 and V1_4 profiles.
  * `parse-authorization-request.test.ts`: Verifies header/signer matching logic, optional `x5c`, and `x509_hash` digest verification.
  * `z-request-object.test.ts`: Tests `x5c` optionality in V1_3 headers while keeping `trust_chain` mandatory in V1_0.
* Run tests with:
  ```bash
  pnpm test