### PR TITLE
fix: support object values in one_of operator for metadata_policy

### DIFF
--- a/.changeset/pretty-insects-mix.md
+++ b/.changeset/pretty-insects-mix.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/io-wallet-oid-federation": patch
+---
+
+fix: support object values in one_of operator for metadata_policy

--- a/packages/oid-federation/src/metadata/operator/standard/__tests__/oneOf.test.ts
+++ b/packages/oid-federation/src/metadata/operator/standard/__tests__/oneOf.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { oneOfOperator } from "../oneOf";
+
+describe("one_of operator", () => {
+  it("accepts arrays of objects as operator values", () => {
+    expect(
+      oneOfOperator.operatorSchema.safeParse([
+        { format: "dc+sd-jwt" },
+        { format: "mso_mdoc" },
+      ]).success,
+    ).toBe(true);
+  });
+
+  it("accepts objects as metadata parameter values", () => {
+    expect(
+      oneOfOperator.parameterSchema.safeParse({
+        format: "dc+sd-jwt",
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/oid-federation/src/metadata/operator/standard/oneOf.ts
+++ b/packages/oid-federation/src/metadata/operator/standard/oneOf.ts
@@ -10,15 +10,13 @@ export const oneOfOperator = createPolicyOperatorSchema({
   mergeStrategy: MetadataMergeStrategy.Intersection,
   operatorJsonValues: [
     z.array(z.string()),
-    // TODO: See how we want to we handle the comparison of objects
-    // z.array(z.record(z.string().or(z.number()), z.unknown())),
+    z.array(z.record(z.string(), z.unknown())),
     z.array(z.number()),
   ],
   orderOfApplication: MetadataOrderOfApplication.AfterDefault,
   parameterJsonValues: [
     z.string(),
-    // TODO: See how we want to we handle the comparison of objects
-    // z.record(z.string().or(z.number()), z.unknown()),
+    z.record(z.string(), z.unknown()),
     z.number(),
   ],
 });


### PR DESCRIPTION
#### List of Changes

- Extend the `one_of` operator schema to accept arrays of JSON objects, in addition to arrays of strings and numbers.
- Allow JSON objects as metadata parameter values for `one_of`.
- Add regression tests covering both cases.

#### Motivation and Context

OpenID Federation 1.0 section 6.1.3.1.4 defines `one_of` operator values as arrays of strings (mandatory) and optionally arrays of objects or numbers. The schema previously omitted object values, causing valid metadata policy values to be rejected during Entity Statement validation.

This change keeps the standard Federation `one_of` structure unchanged: it remains an array-valued operator applied to an individual metadata parameter.

#### How Has This Been Tested?

- `pnpm test -- --run`
- `pnpm types:check`
- `pnpm lint:check`
- `pnpm format:check`